### PR TITLE
Removing unused clip argument.

### DIFF
--- a/helpers/simulationPlot.R
+++ b/helpers/simulationPlot.R
@@ -398,7 +398,7 @@ simulationPlot <- function(
     )
 
   plotObject <- plotObject +
-    coord_cartesian(xlim = c(min(xBreaks), max(xBreaks)), clip="off") +
+    coord_cartesian(xlim = c(min(xBreaks), max(xBreaks))) +
     scale_x_continuous(expand = c(0,0), breaks = xBreaks, labels = xLabels) +
     scale_color_manual(values=drugColors) +
     scale_fill_manual(values=drugColors)  +


### PR DESCRIPTION
Error on startup:
Error: (converted from warning) Error in coord_cartesian: unused argument (clip = "off")