### PR TITLE
Add Imports of used libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: r
 warnings_are_errors: false
+apt_packages:
+  - libv8-dev

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,40 @@ Authors@R:
            comment = structure("0000-0002-0289-7793", .Names = "ORCID")))
 Description: stanpumpR is open-source software for pharmacokinetic / pharmacodynamic simulation. It is intended to make pharmacokinetics accessible to facilitate perioperative patient care, teaching, and research. stanpumpR may be freely downloaded and used without restriction for non-commericial purposes.
 License: MIT + file LICENSE
+Imports:
+  config,
+  data.table,
+  dplyr,
+  dqshiny,
+  DT,
+  egg,
+  ggplot2  (>= 3.2),
+  ggpubr,
+  grid,
+  jpeg,
+  jsonlite,
+  mailR,
+  officer,
+  openxlsx,
+  png,
+  purrr,
+  R.utils,
+  randomcoloR,
+  RColorBrewer,
+  rhandsontable,
+  rvg,
+  shiny,
+  shinyBS,
+  shinydashboard,
+  shinyjs,
+  shinyWidgets,
+  splines,
+  stringi,
+  tidyr,
 Suggests:
-    testthat
+    devtools,
+    rsconnect,
+    testthat,
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Dependencies will now be installed via `install_deps()`.

Travis-ci will now also install all necessary dependencies