### PR TITLE
Add min R version to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,8 @@ Suggests:
     devtools,
     rsconnect,
     testthat,
+Depends:
+  R (>= 3.6)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
This was discovered because the new version of [cowplot](https://cran.r-project.org/web/packages/cowplot/index.html) depends on R (≥ 3.5.0).

[ggpubr](https://cran.r-project.org/web/packages/ggpubr/index.html) depends on cowplot, but does not specify a dependency version.