### PR TITLE
Remove default parameter values for propofol.

### DIFF
--- a/data/drugs/propofol.R
+++ b/data/drugs/propofol.R
@@ -1,4 +1,4 @@
-propofol <- function(weight = 70, height = 171, age = 50, sex = "male")
+propofol <- function(weight, height, age, sex)
 {
   # Units **************
   # Time: Minutes


### PR DESCRIPTION
All of these parameters are required and having default values could cause unexpected behavior.