### PR TITLE
Fix errors introduced in PR #92

### DIFF
--- a/R/sendSlide.R
+++ b/R/sendSlide.R
@@ -44,8 +44,7 @@ sendSlide <- function(
       emailData$pptxfileName,
       emailData$xlsxfileName
     ),
-    authenticate = TRUE,
-    send = internetConnected # Only send from server
+    authenticate = TRUE
   )
   outputComments("Leaving sendMail()")
   return(emailData$pngfileName)
@@ -249,10 +248,10 @@ generateEmail <- function(values, recipient, plotObject, allResults, plotResults
 
   return(list(
     title = title,
-    bodyText = ,
+    bodyText = bodyText,
     pptxfileName = pptxfileName,
     xlsxfileName = xlsxfileName,
-    pngfileName = pngfileName,
+    pngfileName = pngfileName
     )
   )
 }

--- a/server.R
+++ b/server.R
@@ -541,11 +541,9 @@ server <- function(input, output, session)
         email_password = config$email_password
       )
       output$sentPlot <- renderImage(
-        list(src = img)
-        )
-      # Plot(
-      #   plotObject + labs(title=paste("Image sent to",input$recipient))
-      # )
+        list(src = img),
+        deleteFile = FALSE
+      )
     }
   )
 


### PR DESCRIPTION
- for compatibility with current Shiny version: renderImage now requires argument deleteFile
- removed error from references to old global variable