### PR TITLE
Don't load package datasets from relative path

### DIFF
--- a/R/drugAndEventDefaults.R
+++ b/R/drugAndEventDefaults.R
@@ -12,14 +12,7 @@ drugUnitsSimplify <- function(units) {
 #' @export
 getDrugDefaultsGlobal <- function()
 {
-  if (exists("drugDefaults_global") == FALSE) {
-    # Annoying, Shiny's autoload won't load sysdata.rda, only .R files!
-    # So, when loaded as a package, sysdata.rda will load but not when
-    # the Shiny app is executed using runApp()
-    load('data/sysdata.rda')
-  }
-
-  drugDefaultsDataset <- drugDefaults_global
+  drugDefaultsDataset <- stanpumpR::drugDefaults_global
   drugDefaultsDataset$Units <- strsplit(drugDefaultsDataset$Units, ",")
   drugDefaultsDataset
 }
@@ -41,14 +34,7 @@ getDrugDefaults <- function(drug)
 
 getDrugAndEventDefaultsGlobal <- function()
 {
-  if (!exists("drugDefaults_global") || !exists("eventDefaults")) {
-    # Annoying, Shiny's autoload won't load sysdata.rda, only .R files!
-    # So, when loaded as a package, sysdata.rda will load but not when
-    # the Shiny app is executed using runApp()
-    load('data/sysdata.rda')
-  }
-
-  drugDefaultsDataset <- drugDefaults_global
+  drugDefaultsDataset <- stanpumpR::drugDefaults_global
   drugDefaultsDataset$Units <- strsplit(drugDefaultsDataset$Units, ",")
-  list(drugDefaultsDataset=drugDefaultsDataset, eventDefaults=eventDefaults)
+  list(drugDefaultsDataset=drugDefaultsDataset, eventDefaults=stanpumpR::eventDefaults)
 }

--- a/global.R
+++ b/global.R
@@ -38,10 +38,7 @@ theme_update(
   legend.key = element_blank()
 )
 
-e <- new.env()
-load("data/sysdata.rda", envir=e)
 js_drug_defaults <- paste0("var drug_defaults=",toJSON(stanpumpR::drugDefaults_global))
-rm(e)
 
 blanks <- rep("", 6)
 doseTableInit <- data.frame(

--- a/global.R
+++ b/global.R
@@ -40,7 +40,7 @@ theme_update(
 
 e <- new.env()
 load("data/sysdata.rda", envir=e)
-js_drug_defaults <- paste0("var drug_defaults=",toJSON(rlang::env_get(e, "drugDefaults_global")))
+js_drug_defaults <- paste0("var drug_defaults=",toJSON(stanpumpR::drugDefaults_global))
 rm(e)
 
 blanks <- rep("", 6)


### PR DESCRIPTION
Some scripts try to load "data/sysdata.rda" using load(), rather than simply accessing them via the package. This causes errors when trying to run stanpumpR functions from projects outside of the stanpumpR directory. This pull request resolves this problem.