### PR TITLE
Several user experience improvements

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -464,7 +464,7 @@ app_server <- function(input, output, session) {
 
 
   plotRecovery <- reactive({
-    "Time Until" %in% input$addedPlots
+    input$showThreshold
   })
 
   linetypes <- reactive({

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -1491,8 +1491,7 @@ app_server <- function(input, output, session) {
           col = 13,
           halign = "htRight"
         ) %>%
-        hot_context_menu(allowRowEdit = TRUE, allowColEdit = FALSE) # %>%
-      #    hot_rows(rowHeights = 10) # interferes with cell selection -> other occasions?
+        hot_table(contextMenu = FALSE)
       drugsHOT
     }, name = "output$editDrugsHTML")
   })

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -1374,28 +1374,19 @@ app_server <- function(input, output, session) {
     showModal(
       modalDialog(
         title = paste("Edit Drug Defaults"),
-        tags$div(
-          HTML(
-            paste(
-              tags$span(
-                style="color:red; font-weight:bold ",
-                "This is primarily intended for stanpumpR collaborators. ",
-                "If you believe some drug defaults are incorrect, please contact ",
-                "steven.shafer@stanford.edu. ",
-                "Also, you can easily break your session by entering crazy things. ",
-                "If so, just reload your session. "), sep = ""))
+        div(
+          class = "fw-bold text-danger",
+          "This is primarily intended for stanpumpR collaborators. If you believe some drug defaults are incorrect, please contact",
+          tags$a("steven.shafer@stanford.edu", href = "mailto:steven.shafer@stanford.edu"),
+          ". Also, you can easily break your session by entering crazy things. If so, just reload your session."
         ),
-        rHandsontableOutput(
-          outputId = "editDrugsHTML"
-        ),
-        actionButton(
-          inputId = "drugEditsOK",
-          label = "OK",
-          style="color: #fff; background-color: #337ab7; border-color: #2e6da4"
-        ),
+        br(),
+        shinycssloaders::withSpinner(rHandsontableOutput("editDrugsHTML", height = 350)),
+        br(),
+        actionButton("drugEditsOK", "Apply", class = "btn-primary"),
         tags$button(
           type = "button",
-          class = "btn btn-warning float-right",
+          class = "btn float-right",
           `data-bs-dismiss` = "modal",
           "Cancel"
         ),
@@ -1416,7 +1407,7 @@ app_server <- function(input, output, session) {
         x,
         overflow = 'visible',
         rowHeaders = NULL,
-        height = 220
+        height = 350
       ) %>%
         hot_col(
           col = 1,

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -155,8 +155,13 @@ app_ui <- function() {
                               "blank")
                 ),
                 sliderInput("yaxisHeight", "Y axis height", 150, 350, 200, ticks = FALSE),
+                checkboxInput(
+                  "showThreshold",
+                  "Time until threshold",
+                  value = FALSE
+                ),
                 conditionalPanel(
-                  condition = sprintf("!(input.addedPlots.includes('Time Until') || input.addedPlots.includes('%s') || input.addedPlots.includes('Interaction'))", DRUG_NAME_EVENTS),
+                  condition = sprintf("!(input.showThreshold || input.addedPlots.includes('%s') || input.addedPlots.includes('Interaction'))", DRUG_NAME_EVENTS),
                   checkboxInput(
                     inputId = "logY",
                     label = "Log Y axis",
@@ -171,8 +176,7 @@ app_ui <- function() {
                 checkboxGroupInput(
                   inputId = "addedPlots",
                   label = NULL,
-                  choiceNames = c("MEAC", "Interaction", DRUG_NAME_EVENTS, "Time until threshold"),
-                  choiceValues = c("MEAC", "Interaction", DRUG_NAME_EVENTS, "Time Until")
+                  choices = c("MEAC", "Interaction", DRUG_NAME_EVENTS)
                 )
               ),
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -122,8 +122,8 @@ app_ui <- function() {
                 icon = icon("sliders"),
                 textInput("title", "Title", paste("Simulation on", format(Sys.time()))),
                 textInput("caption", "Caption", "", placeholder = "Enter figure caption"),
-                selectInput("typical", "Show typical", c("none","Mid", "Range"), selected = "Range"),
-                selectInput("normalization", "Normalize to", c("none","Peak plasma", "Peak effect site")),
+                selectInput("typical", "Show typical", c("<none>" = "none","Mid", "Range"), selected = "Range"),
+                selectInput("normalization", "Normalize to", c("<none>" = "none","Peak plasma", "Peak effect site")),
                 selectInput(
                   inputId = "maximum",
                   label = "Max time (minutes)",
@@ -132,27 +132,31 @@ app_ui <- function() {
                 ),
                 selectInput(
                   inputId = "plasmaLinetype",
-                  label = "Plasma",
+                  label = "Plasma line",
                   selected = "blank",
-                  choices = c("solid",
-                              "dashed",
-                              "longdash",
-                              "dotted",
-                              "dotdash",
-                              "twodash",
-                              "blank")
+                  choices = c(
+                    "<none>" = "blank",
+                    "solid",
+                    "dashed",
+                    "longdash",
+                    "dotted",
+                    "dotdash",
+                    "twodash"
+                  )
                 ),
                 selectInput(
                   inputId = "effectsiteLinetype",
-                  label = "Effect site",
+                  label = "Effect site line",
                   selected = "solid",
-                  choices = c("solid",
-                              "dashed",
-                              "longdash",
-                              "dotted",
-                              "dotdash",
-                              "twodash",
-                              "blank")
+                  choices = c(
+                    "<none>" = "blank",
+                    "solid",
+                    "dashed",
+                    "longdash",
+                    "dotted",
+                    "dotdash",
+                    "twodash"
+                  )
                 ),
                 sliderInput("yaxisHeight", "Y axis height", 150, 350, 200, ticks = FALSE),
                 checkboxInput(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -193,7 +193,7 @@ app_ui <- function() {
             ),
 
             actionButton("setTarget", "Suggest Dosing", class = "btn-outline-primary", icon = icon("fas fa-wand-magic-sparkles")),
-            actionButton("editDrugs", "Modify Drug Library", class = "btn-outline-primary", icon = icon("fas fa-pencil"))
+            actionButton("editDrugs", "Drug Library", class = "btn-outline-primary", icon = icon("fas fa-pencil"))
           ),
 
           bslib::layout_columns(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -127,7 +127,7 @@ app_ui <- function() {
                 selectInput(
                   inputId = "maximum",
                   label = "Max time (minutes)",
-                  choices = maxtimes$times,
+                  choices = setNames(maxtimes$times, format(maxtimes$times, scientific = FALSE, trim = TRUE, big.mark = ",")),
                   selected = 60
                 ),
                 selectInput(


### PR DESCRIPTION
- move Time Until checkbox into Graph Options instead of Additional Plots
- Max Time was showing 1e6 instead of the number 1000000
- Max Time was not showing the thousands comma separator (now it's 1,440 instead of 1440)
- changed some of the text of the options in the Graph Options inputs to be more user friendly. For example, "Plasma lina" instead of just "Plasma". Moved all the "blank" options to the top of the list. Any "blank" option is now called "<none>" so that it's easy to distinuish
- don't allow user to add or remove rows from the Modify Drug Library table
- drug library: make the table taller, add a loading icon to the table, make steve's email clickable, simplify the code to generate the paragraph