### PR TITLE
fix validateTime to take care of the case of having only periods

### DIFF
--- a/R/validateTime.R
+++ b/R/validateTime.R
@@ -25,7 +25,7 @@ validateTime <- function(x)
   if (length(parts) > 1) {
     x <- paste(parts[1], paste(parts[-1], collapse = ""), sep = ":")
   }
-  if (x == ".:" || x == ":.") {
+  if (x == ".:" || x == ":." || x == ".") {
     return("0")
   }
 

--- a/tests/testthat/test-validateTime.R
+++ b/tests/testthat/test-validateTime.R
@@ -16,6 +16,10 @@ test_that("'HH:MM' gets parsed correctly", {
     expect_equal(validateTime("08:80"),"09:20")
 })
 
+test_that("A single period returns 0", {
+    expect_equal(validateTime("."), "0")
+})
+
 ## tests for getReferenceTime
 
 test_that("'HH:MM:SS AM' gets parsed correctly", {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed time input values. Certain edge cases, including single dot characters, are now correctly identified as invalid and return a standardized default value instead of proceeding with normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->