### PR TITLE
Remove the concept of different threshold label names, everything should just be called "Threshold"

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -661,7 +661,7 @@ app_server <- function(input, output, session) {
     returnText <- paste0("Time: ", time, ", ",x[1], " Ce: ", signif(drugs()[[drug]]$equiSpace$Ce[j], 2), " ", x[2])
     if (plotRecovery())
     {
-      returnText <- paste0(returnText,", Time until Threshold ",round(drugs()[[drug]]$equiSpace$Recovery[j], 1), " minutes")
+      returnText <- paste0(returnText,", Time until threshold: ",round(drugs()[[drug]]$equiSpace$Recovery[j], 1), " minutes")
     }
     return(returnText)
   }

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -661,7 +661,7 @@ app_server <- function(input, output, session) {
     returnText <- paste0("Time: ", time, ", ",x[1], " Ce: ", signif(drugs()[[drug]]$equiSpace$Ce[j], 2), " ", x[2])
     if (plotRecovery())
     {
-      returnText <- paste0(returnText,", Time until ",drugDefaults()$endCeText[i], " ",round(drugs()[[drug]]$equiSpace$Recovery[j], 1), " minutes")
+      returnText <- paste0(returnText,", Time until Threshold ",round(drugs()[[drug]]$equiSpace$Recovery[j], 1), " minutes")
     }
     return(returnText)
   }
@@ -1362,8 +1362,8 @@ app_server <- function(input, output, session) {
       editDrugsTrigger$depend()
       x <- drugDefaults()
       x$Units <- drugUnitsSimplify(x$Units)
-      # endCe / endCeText are managed via the Drug Thresholds modal
-      x <- x[, !names(x) %in% c("endCe", "endCeText")]
+      # endCe is managed via the Drug Thresholds modal
+      x <- x[, !names(x) == "endCe"]
       drugsHOT <- rhandsontable(
         x,
         overflow = 'visible',
@@ -1440,9 +1440,8 @@ app_server <- function(input, output, session) {
       newDrugDefaults$Typical              <- as.numeric(newDrugDefaults$Typical)
       newDrugDefaults$MEAC                 <- as.numeric(newDrugDefaults$MEAC)
 
-      # endCe / endCeText are not in the table; restore from current values
+      # endCe is not in the table; restore from current values
       newDrugDefaults$endCe     <- current$endCe[match(newDrugDefaults$Drug, current$Drug)]
-      newDrugDefaults$endCeText <- current$endCeText[match(newDrugDefaults$Drug, current$Drug)]
 
       newDrugDefaults$Units <- drugUnitsExpand(newDrugDefaults$Units)
       drugDefaults(newDrugDefaults)

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -1363,7 +1363,7 @@ app_server <- function(input, output, session) {
       x <- drugDefaults()
       x$Units <- drugUnitsSimplify(x$Units)
       # endCe is managed via the Drug Thresholds modal
-      x <- x[, !names(x) == "endCe"]
+      x <- x[, !names(x) %in% "endCe"]
       drugsHOT <- rhandsontable(
         x,
         overflow = 'visible',

--- a/R/server-helpers.R
+++ b/R/server-helpers.R
@@ -72,7 +72,6 @@ recalculatePK <- function(drugs, drugDefaults, doseTable,
     idx <- which(drugDefaults$Drug==drug)
     drugs[[drug]]$Color <- drugDefaults$Color[idx]
     drugs[[drug]]$endCe <- drugDefaults$endCe[idx]
-    drugs[[drug]]$endCeText <- drugDefaults$endCeText[idx]
     outputComments("Getting PK for", drug)
     drugs[[drug]] <- utils::modifyList(
       drugs[[drug]],

--- a/R/simulateDrugsWithCovariates.R
+++ b/R/simulateDrugsWithCovariates.R
@@ -29,7 +29,6 @@ simulateDrugsWithCovariates <- function (dose, events, weight, height, age, sex,
     output[[drug]]$Concentration.Units <- drugDefaults$Concentration.Units
     output[[drug]]$Color               <- drugDefaults$Color
     output[[drug]]$endCe               <- drugDefaults$endCe
-    output[[drug]]$endCeText           <- drugDefaults$endCeText
 
     output[[drug]]$DT                  <- currentDT
     output[[drug]]$ET                  <- events

--- a/R/simulationPlot.R
+++ b/R/simulationPlot.R
@@ -63,14 +63,13 @@ simulationPlot <- function(
       purrr::map_chr(drugs, \(x) as.character(purrr::pluck(x, "lowerTypical"))),
       purrr::map_chr(drugs, \(x) as.character(purrr::pluck(x, "upperTypical"))),
       purrr::map_chr(drugs, \(x) as.character(purrr::pluck(x, "MEAC"))),
-      purrr::map_chr(drugs, \(x) as.character(purrr::pluck(x, "endCe"))),
-      purrr::map_chr(drugs, "endCeText")
+      purrr::map_chr(drugs, \(x) as.character(purrr::pluck(x, "endCe")))
       )
   )
 
   names(plotTable) <- c("Drug", "drugColor", "Concentration.Units",
                         "typical", "lowerTypical", "upperTypical",
-                        "MEAC", "endCe", "endCeText")
+                        "MEAC", "endCe")
 
   outputComments("plotTable created", level = DEBUG_LEVEL_VERBOSE)
 
@@ -247,7 +246,6 @@ simulationPlot <- function(
       newplotTable$ymax <- 200
       newplotTable$Wrap <- "% MEAC"
       newplotTable$endCe <- 0
-      newplotTable$endCeText <- ""
       # don't care about MEAC, maxCp, or maxCe
       plotTable <- rbind(plotTable, newplotTable)
 
@@ -369,7 +367,6 @@ simulationPlot <- function(
     newplotTable$Wrap <- DRUG_NAME_EVENTS
     newplotTable$alpha <- 1
     newplotTable$endCe <- 0
-    newplotTable$endCeText <- ""
     plotTable <- rbind(plotTable, newplotTable)
 
   }
@@ -626,7 +623,7 @@ simulationPlot <- function(
     arrows <- data.frame(
       Drug = plotTable$Drug,
       y = plotTable$endCe,
-      new = ifelse(nchar(plotTable$endCeText)>0,paste0(sprintf('\u2190'), plotTable$endCeText),""),
+      new = ifelse(plotTable$endCe>0,paste0(sprintf('\u2190'), "Threshold"),""),
       x = maximum,
       Wrap <- as.character(plotTable$Wrap)
     )

--- a/R/simulationPlot.R
+++ b/R/simulationPlot.R
@@ -623,7 +623,7 @@ simulationPlot <- function(
     arrows <- data.frame(
       Drug = plotTable$Drug,
       y = plotTable$endCe,
-      new = ifelse(plotTable$endCe>0,paste0(sprintf('\u2190'), "Threshold"),""),
+      new = "\u2190 Threshold",
       x = maximum,
       Wrap <- as.character(plotTable$Wrap)
     )

--- a/inst/extdata/drugDefaults_global.csv
+++ b/inst/extdata/drugDefaults_global.csv
@@ -1,21 +1,21 @@
-Drug,Concentration.Units,Bolus.Units,Infusion.Units,Default.Units,Units,Color,Lower,Upper,Typical,MEAC,endCe,endCeText
-propofol,mcg,mg,mcg/kg/min,mg,"mg,mg/kg,mcg/kg/min,mg/kg/hr",#FFCC00,2.5,4,3,0,1,emergence
-remifentanil,ng,mcg,mcg/kg/min,mcg/kg/min,"mcg,mcg/kg,mcg/kg/min",#0000C0,0.8,2,1.2,1,1,ventilation
-fentanyl,ng,mcg,mcg/kg/hr,mcg,"mcg,mcg/kg,mcg/kg/hr",#0491E2,0.48,1.2,0.72,0.6,0.6,ventilation
-alfentanil,ng,mcg,mcg/kg/hr,mcg,"mcg,mcg/kg,mcg/kg/hr",#0491E2,31.2,78,46.8,39,39,ventilation
-sufentanil,ng,mcg,mcg/kg/hr,mcg,"mcg,mcg/kg,mcg/kg/hr",#0491E2,0.0448,0.112,0.0672,0.056,0.056,ventilation
-morphine,mcg,mg,mg/hr,mg,"mg,mg/hr",#032FED,0.0064,0.016,0.0096,0.008,0.008,ventilation
-pethidine,mcg,mg,mg/hr,mg,"mg,mg/hr",#5155FF,0.2,0.5,0.3,0.25,0.25,ventilation
-hydromorphone,ng,mg,mg/hr,mg,"mg,mg/kg,mg/hr,mg/kg/hr,mg PO,mg IM,mg IN",#032FED,1.2,3,1.8,1.5,1.5,ventilation
-methadone,mcg,mg,mg/hr,mg,"mg,mg/hr",#71C5E8,0.048,0.12,0.072,0.06,0.06,ventilation
-ketamine,mcg,mg,mg/hr,mg,"mg,mg/kg,mg/hr,mg/kg/hr",#FFCC00,0.1,0.16,0.12,0,0.1,emergence
-dexmedetomidine,ng,mcg,mcg/kg/hr,mcg/kg/hr,"mcg,mcg/kg,mcg/hr,mcg/kg/hr",#791AEE,0.4,0.8,10,0,0.4,emerence
-midazolam,mcg,mg,mg/hr,mg,"mg,mg/kg,mg/hr",#E36C0A,0.04,0.12,0.1,0,0.04,wakefulness
-etomidate,mcg,mg,mg/kg/min,mg,"mg,mg/kg/min",#FFCC00,0.4,0.8,0.5,0,0.4,emergence
-lidocaine,mcg,mg,mg/hr,mg,"mg,mg/hr",#B7AE7F,0.5,1.5,1,0,0.5,emergence
-rocuronium,mcg,mg,mg/kg/hr,mg,"mg,mg/kg/hr",#F9423A,1,2.2,1.5,0,1,reversable
-naloxone,ng,mcg,mcg/min,mcg,"mcg,mcg/kg,mg,mg/kg,mcg/min,mcg/kg/min,mg/min,mg/kg/min",#404040,0,0,0,0,1,no effect
-oxytocin,ng,mcg,mcg/min,mcg,"mcg,mg,mg/kg,mcg/min",#008F7D,0.05,0.2,0.1,0,0.05,no effect
-oxycodone,ng,,,mg PO,mg PO,#032FED,10,20,14,12,10,ventilation
-oliceridine,ng,mg,mcg/kg/min,mg,"mg,mcg/kg/min",#FF00CC,18.296,37.504,27.4,27.9,27.4,ventilation
-remimazolam,mcg,mg,mg/hr,mg,"mg,mg/kg,mg/hr",#E36C0A,0.3,0.6,0.2,0,0.2,wakefulness
+Drug,Concentration.Units,Bolus.Units,Infusion.Units,Default.Units,Units,Color,Lower,Upper,Typical,MEAC,endCe
+propofol,mcg,mg,mcg/kg/min,mg,"mg,mg/kg,mcg/kg/min,mg/kg/hr",#FFCC00,2.5,4,3,0,1
+remifentanil,ng,mcg,mcg/kg/min,mcg/kg/min,"mcg,mcg/kg,mcg/kg/min",#0000C0,0.8,2,1.2,1,1
+fentanyl,ng,mcg,mcg/kg/hr,mcg,"mcg,mcg/kg,mcg/kg/hr",#0491E2,0.48,1.2,0.72,0.6,0.6
+alfentanil,ng,mcg,mcg/kg/hr,mcg,"mcg,mcg/kg,mcg/kg/hr",#0491E2,31.2,78,46.8,39,39
+sufentanil,ng,mcg,mcg/kg/hr,mcg,"mcg,mcg/kg,mcg/kg/hr",#0491E2,0.0448,0.112,0.0672,0.056,0.056
+morphine,mcg,mg,mg/hr,mg,"mg,mg/hr",#032FED,0.0064,0.016,0.0096,0.008,0.008
+pethidine,mcg,mg,mg/hr,mg,"mg,mg/hr",#5155FF,0.2,0.5,0.3,0.25,0.25
+hydromorphone,ng,mg,mg/hr,mg,"mg,mg/kg,mg/hr,mg/kg/hr,mg PO,mg IM,mg IN",#032FED,1.2,3,1.8,1.5,1.5
+methadone,mcg,mg,mg/hr,mg,"mg,mg/hr",#71C5E8,0.048,0.12,0.072,0.06,0.06
+ketamine,mcg,mg,mg/hr,mg,"mg,mg/kg,mg/hr,mg/kg/hr",#FFCC00,0.1,0.16,0.12,0,0.1
+dexmedetomidine,ng,mcg,mcg/kg/hr,mcg/kg/hr,"mcg,mcg/kg,mcg/hr,mcg/kg/hr",#791AEE,0.4,0.8,10,0,0.4
+midazolam,mcg,mg,mg/hr,mg,"mg,mg/kg,mg/hr",#E36C0A,0.04,0.12,0.1,0,0.04
+etomidate,mcg,mg,mg/kg/min,mg,"mg,mg/kg/min",#FFCC00,0.4,0.8,0.5,0,0.4
+lidocaine,mcg,mg,mg/hr,mg,"mg,mg/hr",#B7AE7F,0.5,1.5,1,0,0.5
+rocuronium,mcg,mg,mg/kg/hr,mg,"mg,mg/kg/hr",#F9423A,1,2.2,1.5,0,1
+naloxone,ng,mcg,mcg/min,mcg,"mcg,mcg/kg,mg,mg/kg,mcg/min,mcg/kg/min,mg/min,mg/kg/min",#404040,0,0,0,0,1
+oxytocin,ng,mcg,mcg/min,mcg,"mcg,mg,mg/kg,mcg/min",#008F7D,0.05,0.2,0.1,0,0.05
+oxycodone,ng,,,mg PO,mg PO,#032FED,10,20,14,12,10
+oliceridine,ng,mg,mcg/kg/min,mg,"mg,mcg/kg/min",#FF00CC,18.296,37.504,27.4,27.9,27.4
+remimazolam,mcg,mg,mg/hr,mg,"mg,mg/kg,mg/hr",#E36C0A,0.3,0.6,0.2,0,0.2

--- a/tests/testthat/test-simCpCe.R
+++ b/tests/testthat/test-simCpCe.R
@@ -11,7 +11,6 @@ test_that("it returns the correct array", {
   PK <- list(
     Color = "#0000C0",
     endCe = 1,
-    endCeText = "ventilation",
     drug = "remifentanil",
     PK = list(
       default = list(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Hover tooltips now show recovery as "Time until threshold: … minutes".
  * Recovery/threshold annotations use a fixed "← Threshold" label.

* **Product Settings**
  * Drug Defaults editor simplifies handling of threshold fields and restores numeric threshold values only.

* **Tests**
  * Test fixtures updated to match the new tooltip and threshold-field behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->