### PR TITLE
add a "Show time until threshold" checkbox in the Drug Thresholds modal; fixes #233

### DIFF
--- a/R/app_globals.R
+++ b/R/app_globals.R
@@ -18,6 +18,7 @@ bookmarksToExclude <- c(
   "plotContainer_full_screen",
   "thresholdEditsOK",
   "editThresholdsTable",
+  "showThresholdModal",
   "editEventsTableHTML",
   "doseTableHTML",
   "setTarget",

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -1465,7 +1465,7 @@ app_server <- function(input, output, session) {
       modalDialog(
         title = "Drug Thresholds",
         p("Set the threshold concentration for each drug."),
-        br(),
+        checkboxInput("showThresholdModal", "Show time until threshold", value = input$showThreshold),
         shinycssloaders::withSpinner(rHandsontableOutput("editThresholdsTable", height = 350)),
         br(),
         actionButton("thresholdEditsOK", "Apply", class = "btn-primary"),
@@ -1498,6 +1498,7 @@ app_server <- function(input, output, session) {
     newDrugDefaults <- drugDefaults()
     newDrugDefaults$endCe <- as.numeric(tt$Threshold)[match(newDrugDefaults$Drug, tt$Drug)]
     drugDefaults(newDrugDefaults)
+    updateCheckboxInput(session, "showThreshold", value = input$showThresholdModal)
   })
 
   outputComments("Reached the end of server()")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "show time until threshold" checkbox in the Drug Thresholds modal to control whether time-until-threshold values are displayed, with the setting syncing to the main threshold display option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->