### PR TITLE
if any normalization is used, don't show the Time Until Threshold checkboxes; fixes #234

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -1465,7 +1465,8 @@ app_server <- function(input, output, session) {
       modalDialog(
         title = "Drug Thresholds",
         p("Set the threshold concentration for each drug."),
-        checkboxInput("showThresholdModal", "Show time until threshold", value = input$showThreshold),
+        if (input$normalization == "none")
+          checkboxInput("showThresholdModal", "Show time until threshold", value = input$showThreshold),
         shinycssloaders::withSpinner(rHandsontableOutput("editThresholdsTable", height = 350)),
         br(),
         actionButton("thresholdEditsOK", "Apply", class = "btn-primary"),

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -159,10 +159,13 @@ app_ui <- function() {
                   )
                 ),
                 sliderInput("yaxisHeight", "Y axis height", 150, 350, 200, ticks = FALSE),
-                checkboxInput(
-                  "showThreshold",
-                  "Time until threshold",
-                  value = FALSE
+                conditionalPanel(
+                  condition = "input.normalization === 'none'",
+                  checkboxInput(
+                    "showThreshold",
+                    "Time until threshold",
+                    value = FALSE
+                  )
                 ),
                 conditionalPanel(
                   condition = sprintf("!(input.showThreshold || input.addedPlots.includes('%s') || input.addedPlots.includes('%s'))", PLOT_NAME_EVENTS, PLOT_NAME_INTERACTION),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display of the "Show time until threshold" checkbox to appear only when normalization is disabled, ensuring UI clarity when the option is not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->