### PR TITLE
fix error that momentarily shows up when a drug is fully deleted from the plot

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -629,6 +629,10 @@ app_server <- function(input, output, session) {
     drug <- x[1]
     outputComments("Drug identified in xy_str() is", drug)
 
+    # if the panel's drug was just removed, drugs()[[drug]] will be NULL until
+    # the plot re-renders
+    if (!drug %in% names(drugs())) return(NULL)
+
     j <- which.min(abs(e$x - drugs()[[drug]]$equiSpace$Time))
     x[2] <- substr(x[2],2,10)
     x[2] <- substr(x[2],1,nchar(x[2])-1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when removing drugs from the plot panel by properly handling cases where a previously selected drug is no longer available, preventing potential data display errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->