### PR TITLE
docs: architecture map, CLAUDE.md, and add-a-drug guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+Orientation for Claude Code working in this repo. Human-facing docs live in
+[`docs/architecture.html`](docs/architecture.html) (visual map) and
+[`docs/architecture.md`](docs/architecture.md).
+
+## What this is
+
+stanpumpR is a Shiny web app that simulates plasma and effect-site concentrations of
+IV/oral anesthetics from a table of doses plus patient covariates. It is a standard **R
+package** (not a bare Shiny script): the app is `app.R → stanpumpR::run_app()`.
+
+Key architectural fact: concentrations are computed with **closed-form solutions** (sums of
+exponentials from a 3-compartment model), never a numeric ODE solver. This is why edits
+re-render fast.
+
+## Running & testing
+
+```r
+devtools::load_all(".")
+run_app()          # add ?debug=1 to the URL for the live log + profiler
+devtools::test()   # testthat suite
+```
+
+Requires a `config.yml` (copy from `config.yml.sample`). Package versions are pinned with
+**renv** — after pulling `renv.lock` changes run `renv::restore()`.
+
+## The reactive pipeline (all in `R/app_server.R`)
+
+One dependency chain; Shiny re-runs only what an edit invalidates:
+
+```
+inputs (covariates, doseTableHTML, events, graph opts)
+  → doseTableClean() / eventTableClean() / testCovariates()   # clean + validate
+  → drugs()            # A: recalculatePK() → getDrugPK() per drug (covariates → coefficients)
+                       # B: processdoseTable() → simCpCe() per changed drug (simulate)
+  → simulationPlotRetval() = simulationPlot(...)   # build ggplot + result tables
+  → output$PlotSimulation, output$hover_info, Suggest Dosing, email slide
+```
+
+`recalculatePK()` and `processdoseTable()` both mutate a persistent per-drug list and **skip
+unchanged drugs** — preserve that diffing behavior when editing them.
+
+## The PK/PD engine (`R/`)
+
+- `getDrugPK.R` — covariates → micro rate constants → `cube.R` eigenvalues (lambda_1..3) →
+  `ke0` (via `tPeakError.R` + `optimize`) → per-route closed-form coefficients.
+- `simCpCe.R` — unit conversion, route classification, then dispatches to one of:
+  - `advanceClosedForm0.R` (IV, no PK events)
+  - `advanceClosedForm1.R` (time-varying PK via events)
+  - `advanceClosedFormPO_IM_IN.R` (oral / IM / intranasal)
+- `simulateDrugsWithCovariates.R` — exported, Shiny-free multi-drug API (used by vignettes/tests).
+- `modelInteraction.R` — propofol × opioid response surface for the interaction facet.
+
+## Drug library — data as code
+
+Each drug is `R/drugs_<name>.R` exporting `<name>(weight, height, age, sex)` that returns a
+list with `PK` (v1..v3, cl1..cl3), `tPeak`, `MEAC`, `typical`, `upper/lowerTypical`,
+`reference`. Metadata (units, color, ranges) is a row in
+`inst/extdata/drugDefaults_global.csv`, loaded via memoised `getDrugDefaultsGlobal()`. The
+drug list comes from that CSV's `Drug` column; functions are invoked by name via
+`eval(call(drug, ...))`.
+
+**To add a drug see [`docs/adding-a-drug.md`](docs/adding-a-drug.md).** Four touch points:
+the `drugs_*.R` file, a CSV row, a `Collate:` entry in `DESCRIPTION`, and a
+`test-drugs-*.R` test.
+
+## Conventions
+
+- Files are flat in `R/`; load order is the explicit `Collate:` list in `DESCRIPTION` — add
+  new files there.
+- Use `outputComments(...)` (not `cat`/`print`) for debug logging; wrap costly reactives in
+  `profileCode(...)`.
+- New user-facing inputs that should NOT be bookmarked go in `bookmarksToExclude`
+  (`R/app_globals.R`).
+- Times are stored as elapsed minutes internally; `clockTimeToDelta.R` / `deltaToClockTime.R`
+  convert to/from wall-clock display.
+- Commit `DESCRIPTION` **and** `renv.lock` together when adding a dependency.

--- a/docs/adding-a-drug.md
+++ b/docs/adding-a-drug.md
@@ -1,0 +1,135 @@
+# Adding a drug to stanpumpR
+
+stanpumpR is designed so that adding a drug is a small, self-contained change — the goal is to
+let outside investigators contribute and maintain the pharmacokinetics for individual drugs.
+A new drug touches **four** places. None of the engine code needs to change.
+
+> Prerequisite: read the [architecture map](architecture.html) first if you haven't. You only
+> need to understand the *drug library* pattern, not the closed-form solver.
+
+## 1. The model — `R/drugs_<name>.R`
+
+Create a file named after the drug (lowercase, matching the CSV `Drug` value). Export one
+function `<name>(weight, height, age, sex)` that returns a list. Even if the model ignores
+covariates, keep the full signature.
+
+Minimal, covariate-independent example (`alfentanil`):
+
+```r
+alfentanil <- function(weight, height, age, sex)
+{
+  # Units: time in minutes, volumes in liters
+
+  default <- list(
+    v1 = 2.1853,  v2 = 6.698864, v3 = 14.52582,
+    cl1 = 0.1988623, cl2 = 1.433557, cl3 = 0.2469389
+  )
+
+  events <- c("default")
+  PK <- sapply(events, function(x) list(get0(x)))
+
+  tPeak <- 1.4         # minutes to peak effect (drives ke0)
+  MEAC  <- 39          # minimum effective analgesic/anesthetic concentration
+  typical      <- MEAC * 1.2
+  upperTypical <- MEAC * 0.8
+  lowerTypical <- MEAC * 2.0
+  reference    <- "JPET 1987;240:159-166"
+
+  list(
+    PK = PK, tPeak = tPeak, MEAC = MEAC,
+    typical = typical, upperTypical = upperTypical, lowerTypical = lowerTypical,
+    reference = reference
+  )
+}
+```
+
+Covariate-driven models simply compute `v1..v3` / `cl1..cl3` from the arguments before
+building `default` — see `R/drugs_remifentanil.R` (branches on BMI between the Eleveld and Kim
+models) or `R/drugs_propofol.R`.
+
+### Return-value contract
+
+| Field | Meaning |
+|---|---|
+| `PK` | named list of PK sets, one per event; each has `v1,v2,v3,cl1,cl2,cl3` (liters, L/min). A single-model drug uses one set named `default`. |
+| `tPeak` | time (min) to peak effect site; `getDrugPK()` back-solves `ke0` from it. `0` means no effect-site model. |
+| `MEAC` | reference effect concentration used for the MEAC plot / normalization (`0` if not applicable). |
+| `typical`, `upperTypical`, `lowerTypical` | the shaded "typical range" band on the plot. |
+| `reference` | literature citation (string). |
+
+**Optional — extravascular routes.** To support oral/IM/intranasal dosing, add absorption
+fields to a PK set: `ka_PO`, `bioavailability_PO`, `tlag_PO` (and the `_IM` / `_IN`
+equivalents). `getDrugPK()` builds the matching absorption coefficients and `simCpCe()` routes
+those doses through `advanceClosedFormPO_IM_IN()`. Omit them for an IV-only drug.
+
+**Optional — time-varying PK.** Provide more than one named PK set (e.g. `default`,
+`"CPB Start"`) to switch kinetics on a clinical event; `advanceClosedForm1()` handles the
+transitions. Event names must exist in `inst/extdata/eventDefaults.csv`.
+
+## 2. The metadata — `inst/extdata/drugDefaults_global.csv`
+
+Add one row. Columns:
+
+```
+Drug,Concentration.Units,Bolus.Units,Infusion.Units,Default.Units,Units,Color,Lower,Upper,Typical,MEAC,endCe
+```
+
+- `Drug` — must exactly match the R function name (this CSV is the source of the drug list).
+- `Concentration.Units` — `mcg` or `ng` per mL (sets the internal unit scaling in `simCpCe`).
+- `Bolus.Units` / `Infusion.Units` / `Default.Units` — units offered in the dose grid.
+- `Units` — quoted comma-separated list of all selectable units, e.g. `"mcg,mcg/kg,mcg/kg/min"`.
+- `Color` — hex color for this drug's curves (e.g. `#0000C0`).
+- `Lower,Upper,Typical,MEAC,endCe` — plot band bounds, MEAC, and emergence effect-site level.
+
+Example row (remifentanil):
+
+```
+remifentanil,ng,mcg,mcg/kg/min,mcg/kg/min,"mcg,mcg/kg,mcg/kg/min",#0000C0,0.8,2,1.2,1,1
+```
+
+## 3. Register the file — `DESCRIPTION`
+
+Add the filename to the `Collate:` list (kept roughly alphabetical among the `drugs_*` block):
+
+```
+  drugs_<name>.R
+```
+
+The package loads files in `Collate` order; a file not listed there won't be loaded.
+
+## 4. The test — `tests/testthat/test-drugs-<name>.R`
+
+Pin the returned values at a reference patient so future edits are intentional. Mirror the
+existing drug tests:
+
+```r
+test_that("returns the correct calculations", {
+  weight <- 70; height <- 171; age <- 50; sex <- "male"
+  actual <- <name>(weight, height, age, sex)
+
+  expected <- list(
+    PK = list(default = list(
+      v1 = ..., v2 = ..., v3 = ...,
+      cl1 = ..., cl2 = ..., cl3 = ...
+    )),
+    tPeak = ..., MEAC = ...,
+    typical = ..., upperTypical = ..., lowerTypical = ...,
+    reference = "..."
+  )
+
+  expect_equal_rounded(actual, expected)
+})
+```
+
+`expect_equal_rounded` is defined in `tests/testthat/helpers.R`.
+
+## Verify
+
+```r
+devtools::load_all(".")
+devtools::test(filter = "drugs-<name>")   # unit test
+run_app()                                  # confirm it appears in the dose-grid dropdown and plots
+```
+
+Also run the broader `test-multi-PK` / `test-single-PK` suites, which exercise the full
+`getDrugPK → simCpCe` path against the library.

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,689 @@
+<title>stanpumpR — Architecture Map</title>
+<style>
+  :root {
+    --paper:        #f6f7f8;
+    --surface:      #ffffff;
+    --surface-2:    #eef1f3;
+    --ink:          #1c262e;
+    --ink-soft:     #47555f;
+    --ink-faint:    #6d7a84;
+    --line:         #dbe0e4;
+    --line-strong:  #c3ccd2;
+    /* domain accents: plasma curve = teal, effect-site curve = amber */
+    --plasma:       #0e7c74;
+    --plasma-soft:  #d6ebe9;
+    --effect:       #b9770b;
+    --effect-soft:  #f3e6cd;
+    --slate:        #2c3e50;   /* the app's own bootswatch primary */
+    --danger:       #a23b3b;
+    --radius:       10px;
+    --radius-sm:    6px;
+    --maxw:         960px;
+    --mono: ui-monospace, "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper:       #12181d;
+      --surface:     #1a2229;
+      --surface-2:   #212b33;
+      --ink:         #e6ebee;
+      --ink-soft:    #aab6bd;
+      --ink-faint:   #7d8b94;
+      --line:        #2b363e;
+      --line-strong: #3a4750;
+      --plasma:      #35b3a8;
+      --plasma-soft: #12302e;
+      --effect:      #e0a63d;
+      --effect-soft: #34290f;
+      --slate:       #7d96ad;
+      --danger:      #d1706f;
+    }
+  }
+  :root[data-theme="dark"] {
+    --paper:#12181d; --surface:#1a2229; --surface-2:#212b33;
+    --ink:#e6ebee; --ink-soft:#aab6bd; --ink-faint:#7d8b94;
+    --line:#2b363e; --line-strong:#3a4750;
+    --plasma:#35b3a8; --plasma-soft:#12302e; --effect:#e0a63d; --effect-soft:#34290f;
+    --slate:#7d96ad; --danger:#d1706f;
+  }
+  :root[data-theme="light"] {
+    --paper:#f6f7f8; --surface:#ffffff; --surface-2:#eef1f3;
+    --ink:#1c262e; --ink-soft:#47555f; --ink-faint:#6d7a84;
+    --line:#dbe0e4; --line-strong:#c3ccd2;
+    --plasma:#0e7c74; --plasma-soft:#d6ebe9; --effect:#b9770b; --effect-soft:#f3e6cd;
+    --slate:#2c3e50; --danger:#a23b3b;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--sans);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* ---- Header ---- */
+  header {
+    border-bottom: 1px solid var(--line);
+    background:
+      radial-gradient(120% 140% at 12% -20%, var(--plasma-soft) 0%, transparent 55%),
+      var(--surface);
+  }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    color: var(--plasma);
+    font-weight: 600;
+  }
+  h1 {
+    font-size: clamp(30px, 5vw, 46px);
+    line-height: 1.05;
+    margin: 14px 0 10px;
+    letter-spacing: -0.02em;
+    text-wrap: balance;
+  }
+  h1 .lede-mono { font-family: var(--mono); font-weight: 600; }
+  .dek {
+    font-size: 18px;
+    color: var(--ink-soft);
+    max-width: 60ch;
+    margin: 0 0 26px;
+    text-wrap: pretty;
+  }
+  header .wrap { padding-top: 46px; padding-bottom: 40px; }
+
+  .facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1px;
+    background: var(--line);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+  .fact { background: var(--surface); padding: 14px 16px; }
+  .fact dt {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .1em;
+    text-transform: uppercase; color: var(--ink-faint); margin-bottom: 5px;
+  }
+  .fact dd { margin: 0; font-size: 14px; font-weight: 600; color: var(--ink); }
+  .fact dd span { font-weight: 400; color: var(--ink-soft); }
+
+  /* ---- Sections ---- */
+  section { padding: 52px 0; border-bottom: 1px solid var(--line); }
+  .sec-label {
+    font-family: var(--mono); font-size: 12px; letter-spacing: .14em;
+    text-transform: uppercase; color: var(--ink-faint); font-weight: 600;
+    display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
+  }
+  .sec-label::before {
+    content: ""; width: 22px; height: 2px; background: var(--plasma); display: inline-block;
+  }
+  h2 {
+    font-size: clamp(23px, 3.4vw, 30px); margin: 0 0 12px;
+    letter-spacing: -0.015em; text-wrap: balance;
+  }
+  .sec-intro { color: var(--ink-soft); max-width: 66ch; margin: 0 0 30px; font-size: 16px; }
+  h3 { font-size: 17px; margin: 0 0 4px; letter-spacing: -0.01em; }
+
+  code, .file, .fn {
+    font-family: var(--mono);
+    font-size: 0.86em;
+    background: var(--surface-2);
+    padding: 1.5px 6px;
+    border-radius: 4px;
+    color: var(--ink);
+    white-space: nowrap;
+  }
+  .fn { color: var(--plasma); background: var(--plasma-soft); }
+  p { text-wrap: pretty; }
+  a { color: var(--plasma); }
+
+  /* ---- Pipeline diagram ---- */
+  .pipe { display: flex; flex-direction: column; gap: 0; }
+  .stage {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--stage-c, var(--slate));
+    border-radius: var(--radius);
+    padding: 16px 20px;
+    z-index: 1;
+  }
+  .stage + .connector { height: 26px; display: flex; justify-content: center; align-items: center; }
+  .connector::before {
+    content: ""; width: 2px; height: 100%; background: var(--line-strong);
+  }
+  .connector .arrow {
+    position: absolute; width: 9px; height: 9px; border-right: 2px solid var(--line-strong);
+    border-bottom: 2px solid var(--line-strong); transform: translateY(-4px) rotate(45deg);
+  }
+  .stage-top { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+  .stage-num {
+    font-family: var(--mono); font-size: 12px; font-weight: 700;
+    color: var(--stage-c, var(--slate));
+    border: 1px solid currentColor; border-radius: 5px; padding: 1px 6px; flex: none;
+  }
+  .stage h3 { margin: 0; }
+  .stage-files { margin-left: auto; display: flex; gap: 6px; flex-wrap: wrap; }
+  .stage p { margin: 8px 0 0; color: var(--ink-soft); font-size: 14.5px; }
+  .stage .reactives { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
+  .chip {
+    font-family: var(--mono); font-size: 11.5px; padding: 2px 8px; border-radius: 20px;
+    background: var(--surface-2); color: var(--ink-soft); border: 1px solid var(--line);
+    white-space: nowrap;
+  }
+  .chip.r { color: var(--plasma); border-color: var(--plasma-soft); background: var(--plasma-soft); }
+
+  /* ---- Component catalog ---- */
+  .layers { display: flex; flex-direction: column; gap: 16px; }
+  .layer {
+    border: 1px solid var(--line); border-radius: var(--radius);
+    background: var(--surface); overflow: hidden;
+  }
+  .layer-head {
+    display: flex; align-items: center; gap: 12px;
+    padding: 13px 18px; background: var(--surface-2); border-bottom: 1px solid var(--line);
+  }
+  .layer-head .tag {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase;
+    color: #fff; background: var(--lc, var(--slate)); padding: 3px 9px; border-radius: 20px; font-weight: 600;
+    flex: none;
+  }
+  .layer-head h3 { margin: 0; font-size: 16px; }
+  .layer-head .role { margin-left: auto; color: var(--ink-faint); font-size: 13px; }
+  .layer-body { padding: 6px 18px 16px; }
+  .frow {
+    display: grid; grid-template-columns: 210px 1fr; gap: 4px 18px;
+    padding: 10px 0; border-bottom: 1px dashed var(--line);
+  }
+  .frow:last-child { border-bottom: 0; }
+  .frow .fname { font-family: var(--mono); font-size: 13px; color: var(--ink); font-weight: 600; }
+  .frow .fdesc { color: var(--ink-soft); font-size: 14px; }
+  @media (max-width: 620px) { .frow { grid-template-columns: 1fr; gap: 2px; } }
+
+  /* ---- generic cards ---- */
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 14px; }
+  .card {
+    border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface);
+    padding: 16px 18px;
+  }
+  .card h3 { color: var(--ink); display: flex; align-items: center; gap: 8px; }
+  .card .k { font-family: var(--mono); font-size: 11px; color: var(--effect); text-transform: uppercase; letter-spacing:.08em; }
+  .card p { margin: 6px 0 0; font-size: 14px; color: var(--ink-soft); }
+  .card .files { margin-top: 10px; display: flex; gap: 5px; flex-wrap: wrap; }
+
+  /* ---- engine steps ---- */
+  .engine { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 720px){ .engine { grid-template-columns: 1fr; } }
+  .ecol { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); overflow:hidden; }
+  .ecol-head { padding: 12px 16px; font-weight: 700; font-size: 14px; display:flex; align-items:center; gap:8px;
+    border-bottom: 1px solid var(--line); }
+  .ecol-head .dot { width: 9px; height: 9px; border-radius: 50%; flex:none; }
+  .estep { padding: 12px 16px; border-bottom: 1px dashed var(--line); }
+  .estep:last-child { border-bottom: 0; }
+  .estep .lbl { font-family: var(--mono); font-size: 12.5px; font-weight: 700; color: var(--ink); }
+  .estep .txt { font-size: 13.5px; color: var(--ink-soft); margin-top: 3px; }
+  .estep .out { font-family: var(--mono); font-size: 11.5px; color: var(--plasma); margin-top: 5px; }
+
+  .note {
+    display: flex; gap: 12px; align-items: flex-start;
+    background: var(--effect-soft); border: 1px solid var(--effect);
+    border-radius: var(--radius); padding: 14px 16px; margin-top: 26px;
+  }
+  .note .mk { font-family: var(--mono); font-weight: 700; color: var(--effect); font-size: 13px; flex: none; }
+  .note p { margin: 0; font-size: 14px; color: var(--ink); }
+
+  footer { padding: 34px 0 60px; color: var(--ink-faint); font-size: 13px; }
+  footer .wrap { display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+  footer code { font-size: 12px; }
+</style>
+
+<header>
+  <div class="wrap">
+    <div class="eyebrow">Architecture Map · R / Shiny package</div>
+    <h1><span class="lede-mono">stanpumpR</span> — a reactive PK/PD anesthetic simulator</h1>
+    <p class="dek">
+      A Shiny web app that turns a table of drug doses plus a patient's covariates into
+      predicted plasma and effect-site concentration curves — using closed-form
+      pharmacokinetic solutions rather than a numeric ODE solver. Packaged as a standard
+      R package with a golem-style <code>ui / server / run</code> split.
+    </p>
+    <dl class="facts">
+      <div class="fact"><dt>Language</dt><dd>R <span>≥ 4.1</span></dd></div>
+      <div class="fact"><dt>Framework</dt><dd>Shiny <span>+ bslib 5</span></dd></div>
+      <div class="fact"><dt>Structure</dt><dd>R package <span>~60 files</span></dd></div>
+      <div class="fact"><dt>Drug library</dt><dd>23 drugs <span>data-as-code</span></dd></div>
+      <div class="fact"><dt>Deps lock</dt><dd>renv <span>renv.lock</span></dd></div>
+      <div class="fact"><dt>Deploy</dt><dd>shinyapps <span>on merge</span></dd></div>
+    </dl>
+  </div>
+</header>
+
+<!-- ======================= PIPELINE ======================= -->
+<section id="pipeline">
+  <div class="wrap">
+    <div class="sec-label">The request → render pipeline</div>
+    <h2>One reactive chain, dose table to plot</h2>
+    <p class="sec-intro">
+      Every edit — a covariate, a dose cell, a graph option — invalidates a link in a single
+      dependency chain inside <code>app_server.R</code>. Shiny re-runs only the downstream
+      reactives. The heavy computation lives in the last two stages.
+    </p>
+
+    <div class="pipe">
+
+      <div class="stage" style="--stage-c: var(--slate)">
+        <div class="stage-top">
+          <span class="stage-num">01</span>
+          <h3>Inputs</h3>
+          <div class="stage-files"><span class="file">app_ui.R</span></div>
+        </div>
+        <p>
+          <code>bslib::page_navbar</code> sidebar collects patient profile (age, weight, height,
+          sex), graph options, and added plots; a <code>rhandsontable</code> holds the editable
+          dose table; a second grid holds events. Clicks on the plot itself add or edit doses.
+        </p>
+        <div class="reactives">
+          <span class="chip">input$age / weight / height / sex</span>
+          <span class="chip">input$doseTableHTML</span>
+          <span class="chip">input$maximum</span>
+          <span class="chip">plot_click / plot_dblclick</span>
+        </div>
+      </div>
+      <div class="connector"><span class="arrow"></span></div>
+
+      <div class="stage" style="--stage-c: var(--slate)">
+        <div class="stage-top">
+          <span class="stage-num">02</span>
+          <h3>Normalize &amp; validate</h3>
+          <div class="stage-files"><span class="file">server-helpers.R</span><span class="file">validate*.R</span></div>
+        </div>
+        <p>
+          Raw inputs become clean reactive state. <span class="fn">cleanDT()</span> coerces the
+          dose grid and drops blank rows; clock times convert to elapsed minutes;
+          <span class="fn">checkNumericCovariates()</span> guards the patient values. A
+          draft / undo / redo stack buffers table edits before <code>Apply</code>.
+        </p>
+        <div class="reactives">
+          <span class="chip r">doseTableClean()</span>
+          <span class="chip r">eventTableClean()</span>
+          <span class="chip r">testCovariates()</span>
+          <span class="chip r">weight() / height() / age() / sex()</span>
+        </div>
+      </div>
+      <div class="connector"><span class="arrow"></span></div>
+
+      <div class="stage" style="--stage-c: var(--plasma)">
+        <div class="stage-top">
+          <span class="stage-num">03</span>
+          <h3>Resolve pharmacokinetics</h3>
+          <div class="stage-files"><span class="file">server-helpers.R</span><span class="file">getDrugPK.R</span></div>
+        </div>
+        <p>
+          <span class="fn">recalculatePK()</span> walks the drugs named in the dose table and,
+          per drug, calls <span class="fn">getDrugPK()</span> to turn the patient's covariates
+          into a full set of rate constants, eigenvalues, and closed-form coefficients. Results
+          are cached on a per-drug list and only recomputed when covariates change.
+        </p>
+        <div class="reactives">
+          <span class="chip r">drugs()  ·  step A</span>
+          <span class="chip">getDrugDefaults()</span>
+        </div>
+      </div>
+      <div class="connector"><span class="arrow"></span></div>
+
+      <div class="stage" style="--stage-c: var(--plasma)">
+        <div class="stage-top">
+          <span class="stage-num">04</span>
+          <h3>Simulate concentrations</h3>
+          <div class="stage-files"><span class="file">processdoseTable.R</span><span class="file">simCpCe.R</span></div>
+        </div>
+        <p>
+          <span class="fn">processdoseTable()</span> diffs each drug's doses against the cached
+          result and re-simulates only what changed — calling <span class="fn">simCpCe()</span>,
+          which converts dose units, classifies bolus / infusion / oral routes, and dispatches to
+          the right closed-form solver. Output is a tidy time × site table per drug.
+        </p>
+        <div class="reactives">
+          <span class="chip r">drugs()  ·  step B</span>
+          <span class="chip">results · equiSpace · max</span>
+        </div>
+      </div>
+      <div class="connector"><span class="arrow"></span></div>
+
+      <div class="stage" style="--stage-c: var(--effect)">
+        <div class="stage-top">
+          <span class="stage-num">05</span>
+          <h3>Assemble the plot</h3>
+          <div class="stage-files"><span class="file">simulationPlot.R</span></div>
+        </div>
+        <p>
+          <span class="fn">simulationPlot()</span> stitches every drug's curves into one
+          <code>ggplot2</code> object — plasma vs effect-site linetypes, per-drug colors,
+          normalization, log axis, and optional MEAC / drug-interaction / events facets. Returns
+          <code>plotObject</code> plus the underlying <code>allResults</code> / <code>plotResults</code> tables.
+        </p>
+        <div class="reactives">
+          <span class="chip r">simulationPlotRetval()</span>
+          <span class="chip">plotObject · plotHeight</span>
+        </div>
+      </div>
+      <div class="connector"><span class="arrow"></span></div>
+
+      <div class="stage" style="--stage-c: var(--effect)">
+        <div class="stage-top">
+          <span class="stage-num">06</span>
+          <h3>Render &amp; interact</h3>
+          <div class="stage-files"><span class="file">app_server.R</span></div>
+        </div>
+        <p>
+          <code>output$PlotSimulation</code> draws the plot; hover reports precise concentrations,
+          click adds a dose, double-click edits a drug. The same result tables feed the
+          <code>Suggest Dosing</code> solver and the emailed PowerPoint slide.
+        </p>
+        <div class="reactives">
+          <span class="chip">output$PlotSimulation</span>
+          <span class="chip">output$hover_info</span>
+          <span class="chip">URL bookmarking</span>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="note">
+      <span class="mk">WHY IT'S FAST</span>
+      <p>
+        Both <span class="fn">recalculatePK()</span> and <span class="fn">processdoseTable()</span>
+        mutate a persistent per-drug list and skip any drug whose inputs are unchanged. Combined
+        with closed-form solutions (no ODE integration), a dose edit re-simulates just the one drug
+        it touched.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ======================= ENGINE ======================= -->
+<section id="engine">
+  <div class="wrap">
+    <div class="sec-label">The computational core</div>
+    <h2>Closed-form three-compartment kinetics</h2>
+    <p class="sec-intro">
+      stanpumpR never numerically integrates. Each drug is a mammillary 3-compartment model with an
+      effect-site link; the disposition is solved analytically once per patient, then evaluated at
+      every time point as a sum of exponentials.
+    </p>
+
+    <div class="engine">
+      <div class="ecol">
+        <div class="ecol-head"><span class="dot" style="background:var(--plasma)"></span>A · Parameterize the patient — <span class="fn">getDrugPK.R</span></div>
+        <div class="estep">
+          <div class="lbl">drug function → V/Cl</div>
+          <div class="txt"><code>eval(call(drug, weight, height, age, sex))</code> runs the drug's own covariate model (e.g. Eleveld / Kim for remifentanil) to yield <code>v1..v3</code>, <code>cl1..cl3</code>, <code>tPeak</code>, <code>MEAC</code>.</div>
+        </div>
+        <div class="estep">
+          <div class="lbl">micro rate constants</div>
+          <div class="txt">Volumes &amp; clearances become <code>k10, k12, k13, k21, k31</code>.</div>
+        </div>
+        <div class="estep">
+          <div class="lbl">cube() → eigenvalues</div>
+          <div class="txt"><span class="fn">cube()</span> solves the characteristic cubic for the disposition rates.</div>
+          <div class="out">→ lambda_1, lambda_2, lambda_3</div>
+        </div>
+        <div class="estep">
+          <div class="lbl">effect-site link</div>
+          <div class="txt"><span class="fn">tPeakError()</span> + <code>optimize()</code> back-solve <code>ke0</code> from the drug's time-to-peak-effect.</div>
+          <div class="out">→ ke0</div>
+        </div>
+        <div class="estep">
+          <div class="lbl">closed-form coefficients</div>
+          <div class="txt">Per route — bolus, infusion, PO, IM, IN — precompute the exponential coefficients for plasma &amp; effect site.</div>
+          <div class="out">→ p_coef_* / e_coef_*</div>
+        </div>
+      </div>
+
+      <div class="ecol">
+        <div class="ecol-head"><span class="dot" style="background:var(--effect)"></span>B · Advance the doses — <span class="fn">simCpCe.R</span></div>
+        <div class="estep">
+          <div class="lbl">unit conversion</div>
+          <div class="txt">mg / mcg / ng, per-kg, and per-hour doses are all reduced to base units against the drug's concentration unit.</div>
+        </div>
+        <div class="estep">
+          <div class="lbl">route classification</div>
+          <div class="txt">Each dose flagged <code>Bolus</code>, infusion, or <code>PO / IM / IN</code>.</div>
+        </div>
+        <div class="estep">
+          <div class="lbl">solver dispatch</div>
+          <div class="txt">
+            IV, no events → <span class="fn">advanceClosedForm0()</span><br>
+            oral / IM / IN → <span class="fn">advanceClosedFormPO_IM_IN()</span><br>
+            time-varying PK events → <span class="fn">advanceClosedForm1()</span>
+          </div>
+        </div>
+        <div class="estep">
+          <div class="lbl">superposition</div>
+          <div class="txt">Each dose's contribution is summed over the exponential basis at every step; <span class="fn">convertState.R</span> carries state across PK-event boundaries.</div>
+          <div class="out">→ Time · Plasma · Effect Site · Recovery</div>
+        </div>
+        <div class="estep">
+          <div class="lbl">resample &amp; normalize</div>
+          <div class="txt">Curves are interpolated to an even grid (<code>equiSpace</code>), normalized to peak Cp/Ce, and scaled against MEAC.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="cards" style="margin-top:16px">
+      <div class="card">
+        <span class="k">multi-drug library API</span>
+        <h3>simulateDrugsWithCovariates</h3>
+        <p>The exported, Shiny-free entry point: loops drugs, calls <code>getDrugPK</code> → <code>simCpCe</code>, and returns per-drug results. What the vignettes and tests drive.</p>
+        <div class="files"><span class="file">simulateDrugsWithCovariates.R</span></div>
+      </div>
+      <div class="card">
+        <span class="k">pharmacodynamics</span>
+        <h3>Drug interaction surface</h3>
+        <p><span class="fn">modelInteraction()</span> computes a propofol × opioid response surface for the optional interaction facet.</p>
+        <div class="files"><span class="file">modelInteraction.R</span><span class="file">CE.R</span><span class="file">calculateCe.R</span></div>
+      </div>
+      <div class="card">
+        <span class="k">covariate helpers</span>
+        <h3>Body-size &amp; recovery</h3>
+        <p><span class="fn">lbmJames()</span> lean body mass; <span class="fn">recoveryCalc()</span> time-to-threshold; <span class="fn">setLinetypes()</span> plasma/effect styling.</p>
+        <div class="files"><span class="file">lbmJames.R</span><span class="file">recoveryCalc.R</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ======================= DRUG LIBRARY ======================= -->
+<section id="drugs">
+  <div class="wrap">
+    <div class="sec-label">Drug library — data as code</div>
+    <h2>One function per drug, one CSV for defaults</h2>
+    <p class="sec-intro">
+      Adding a drug means adding one <code>drugs_&lt;name&gt;.R</code> file and one row in the
+      defaults CSV — the pattern the project is explicitly built to let outside investigators
+      contribute to.
+    </p>
+    <div class="cards">
+      <div class="card">
+        <span class="k">the model · 23 files</span>
+        <h3>drugs_*.R</h3>
+        <p>
+          Each exports a function <code>drug(weight, height, age, sex)</code> returning
+          compartment <code>PK</code>, <code>tPeak</code>, and <code>MEAC</code>. Bodies encode the
+          published covariate models — often branching on BMI or sex (propofol, remifentanil,
+          dexmedetomidine…). Called by name via <code>eval(call(drug, …))</code>.
+        </p>
+      </div>
+      <div class="card">
+        <span class="k">the metadata</span>
+        <h3>drugDefaults_global.csv</h3>
+        <p>
+          Colors, concentration &amp; dose units, typical ranges, MEAC, and emergence thresholds.
+          Loaded once via memoised <span class="fn">getDrugDefaultsGlobal()</span>;
+          <span class="fn">getDrugDefaults(drug)</span> subsets one row.
+        </p>
+        <div class="files"><span class="file">drugAndEventDefaults.R</span><span class="file">inst/extdata/</span></div>
+      </div>
+      <div class="card">
+        <span class="k">events</span>
+        <h3>eventDefaults.csv</h3>
+        <p>
+          Named clinical events (e.g. surgical stimulus) that can switch a drug to alternate PK
+          mid-simulation, driving <span class="fn">advanceClosedForm1()</span>.
+        </p>
+        <div class="files"><span class="file">drugAndEventDefaults.R</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ======================= COMPONENT CATALOG ======================= -->
+<section id="catalog">
+  <div class="wrap">
+    <div class="sec-label">Component catalog</div>
+    <h2>The <code>R/</code> tree by responsibility</h2>
+    <p class="sec-intro">
+      Files are flat in <code>R/</code> and wired together by the package <code>Collate</code>
+      order in <code>DESCRIPTION</code>. Grouped here by the job they do.
+    </p>
+
+    <div class="layers">
+
+      <div class="layer" style="--lc: var(--slate)">
+        <div class="layer-head"><span class="tag">Shell</span><h3>App bootstrap &amp; framework</h3><span class="role">entry + wiring</span></div>
+        <div class="layer-body">
+          <div class="frow"><span class="fname">app.R</span><span class="fdesc">One line: <code>stanpumpR::run_app()</code> — the deploy entry point.</span></div>
+          <div class="frow"><span class="fname">app_run.R</span><span class="fdesc">Loads libraries, merges <code>config.yml</code> with defaults, sets the ggplot theme, mounts assets, launches <code>shinyApp()</code> with URL bookmarking.</span></div>
+          <div class="frow"><span class="fname">app_ui.R</span><span class="fdesc">The entire bslib UI — navbar, sidebar accordions, dose/event grids, plot card, debug panel.</span></div>
+          <div class="frow"><span class="fname">app_server.R</span><span class="fdesc">The 46 KB reactive heart — every reactive, observer, output, and modal.</span></div>
+          <div class="frow"><span class="fname">app_globals.R</span><span class="fdesc">Initial tables, bookmark exclusion list, and the <span class="fn">outputComments()</span> logger.</span></div>
+          <div class="frow"><span class="fname">globalVariables.R · zzz.R · stanpumpR-package.R</span><span class="fdesc">Package plumbing and NSE variable declarations.</span></div>
+        </div>
+      </div>
+
+      <div class="layer" style="--lc: var(--slate)">
+        <div class="layer-head"><span class="tag">Reactive glue</span><h3>Server helpers &amp; UI widgets</h3><span class="role">state + inputs</span></div>
+        <div class="layer-body">
+          <div class="frow"><span class="fname">server-helpers.R</span><span class="fdesc"><span class="fn">recalculatePK</span>, <span class="fn">cleanDT</span>, <span class="fn">checkNumericCovariates</span>, reactive triggers, intro modal.</span></div>
+          <div class="frow"><span class="fname">shiny-utils.R</span><span class="fdesc">UI builders — <span class="fn">inputWithChoices</span>, <span class="fn">addHotHooks</span>, inline-input helpers.</span></div>
+          <div class="frow"><span class="fname">createHOT.R</span><span class="fdesc">Builds the <code>rhandsontable</code> dose grid from the current table + drug colors.</span></div>
+          <div class="frow"><span class="fname">processdoseTable.R</span><span class="fdesc">Per-drug diff-and-simulate driver (pipeline step 04).</span></div>
+          <div class="frow"><span class="fname">validateDose.R · validateTime.R</span><span class="fdesc">Input guards for dose amounts and clock/elapsed times.</span></div>
+        </div>
+      </div>
+
+      <div class="layer" style="--lc: var(--plasma)">
+        <div class="layer-head"><span class="tag">PK/PD engine</span><h3>The math core</h3><span class="role">closed-form solver</span></div>
+        <div class="layer-body">
+          <div class="frow"><span class="fname">getDrugPK.R</span><span class="fdesc">Covariates → rate constants, eigenvalues, and per-route coefficients.</span></div>
+          <div class="frow"><span class="fname">cube.R</span><span class="fdesc">Solves the disposition cubic for lambda_1..3.</span></div>
+          <div class="frow"><span class="fname">simCpCe.R</span><span class="fdesc">Single-drug simulation: units → route → solver dispatch.</span></div>
+          <div class="frow"><span class="fname">advanceClosedForm0 / 1 / PO_IM_IN.R</span><span class="fdesc">The three closed-form solvers (IV, event-varying, extravascular).</span></div>
+          <div class="frow"><span class="fname">advanceState.R · advanceStatePO.R · convertState.R</span><span class="fdesc">Carry compartment state across dose &amp; event boundaries.</span></div>
+          <div class="frow"><span class="fname">CE.R · calculateCe.R · tPeakError.R</span><span class="fdesc">Effect-site concentration and <code>ke0</code> fitting.</span></div>
+          <div class="frow"><span class="fname">modelInteraction.R · recoveryCalc.R · lbmJames.R</span><span class="fdesc">Interaction surface, recovery thresholds, body-size scaling.</span></div>
+          <div class="frow"><span class="fname">simulateDrugsWithCovariates.R</span><span class="fdesc">Exported multi-drug convenience API (no Shiny).</span></div>
+        </div>
+      </div>
+
+      <div class="layer" style="--lc: var(--effect)">
+        <div class="layer-head"><span class="tag">Output</span><h3>Plot, dosing advisor &amp; export</h3><span class="role">present + share</span></div>
+        <div class="layer-body">
+          <div class="frow"><span class="fname">simulationPlot.R</span><span class="fdesc">Assembles the composite <code>ggplot2</code> figure and its data tables.</span></div>
+          <div class="frow"><span class="fname">setLinetypes.R</span><span class="fdesc">Maps normalization + user choices to plasma/effect linetypes.</span></div>
+          <div class="frow"><span class="fname">suggest.R</span><span class="fdesc">"Suggest Dosing" — optimizes a regimen to hit a target effect-site concentration.</span></div>
+          <div class="frow"><span class="fname">sendSlide.R</span><span class="fdesc">Renders an <code>officer</code> PowerPoint slide from <code>Template.pptx</code> and emails it via <code>mailR</code>.</span></div>
+        </div>
+      </div>
+
+      <div class="layer" style="--lc: var(--ink-faint)">
+        <div class="layer-head"><span class="tag">Util</span><h3>Time &amp; misc</h3><span class="role">shared</span></div>
+        <div class="layer-body">
+          <div class="frow"><span class="fname">clockTimeToDelta.R · deltaToClockTime.R · hourMinute.R</span><span class="fdesc">Convert between wall-clock procedure times and elapsed minutes.</span></div>
+          <div class="frow"><span class="fname">utils.R · drugAndEventDefaults.R</span><span class="fdesc">Small shared helpers and the memoised defaults loaders.</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<!-- ======================= FEATURES + INFRA ======================= -->
+<section id="aux" style="border-bottom:0">
+  <div class="wrap">
+    <div class="sec-label">Around the core</div>
+    <h2>Features, assets &amp; infrastructure</h2>
+
+    <div class="cards">
+      <div class="card">
+        <span class="k">feature</span>
+        <h3>Suggest Dosing</h3>
+        <p>Given a target drug and end time, <span class="fn">suggest()</span> optimizes bolus + infusion amounts to reach and hold a target concentration.</p>
+        <div class="files"><span class="file">suggest.R</span></div>
+      </div>
+      <div class="card">
+        <span class="k">feature</span>
+        <h3>Email a slide</h3>
+        <p>Builds a branded PPTX from the current simulation and mails it — plot, dose table, and a URL that reconstructs the exact state.</p>
+        <div class="files"><span class="file">sendSlide.R</span><span class="file">Template.pptx</span></div>
+      </div>
+      <div class="card">
+        <span class="k">feature</span>
+        <h3>Editors &amp; modals</h3>
+        <p>In-app Drug Library and Drug Thresholds editors, plus click-to-add-dose / double-click-to-edit driven from plot coordinates.</p>
+        <div class="files"><span class="file">app_server.R</span></div>
+      </div>
+      <div class="card">
+        <span class="k">state</span>
+        <h3>URL bookmarking</h3>
+        <p>Shiny <code>enableBookmarking="url"</code> encodes inputs into a shareable link; <code>bookmarksToExclude</code> keeps transient UI state out.</p>
+        <div class="files"><span class="file">app_globals.R</span></div>
+      </div>
+      <div class="card">
+        <span class="k">observability</span>
+        <h3>Debug &amp; profiler</h3>
+        <p><code>&amp;debug=1</code> reveals a live log (<span class="fn">outputComments</span>) and a per-reactive profiler (<span class="fn">profileCode</span>).</p>
+        <div class="files"><span class="file">app_globals.R</span><span class="file">app_server.R</span></div>
+      </div>
+      <div class="card">
+        <span class="k">front-end assets</span>
+        <h3>www/</h3>
+        <p><code>app.css</code>, <code>app.js</code>, and <code>hot_funs.js</code> — Handsontable copy/paste hooks and drug-default injection into the client.</p>
+        <div class="files"><span class="file">inst/www/</span></div>
+      </div>
+      <div class="card">
+        <span class="k">config</span>
+        <h3>config.yml</h3>
+        <p>Environment-specific title, help link, and debug flag, merged over <code>DEFAULT_CONFIG</code> at launch.</p>
+        <div class="files"><span class="file">config.yml</span><span class="file">app_run.R</span></div>
+      </div>
+      <div class="card">
+        <span class="k">reproducibility</span>
+        <h3>renv</h3>
+        <p><code>renv.lock</code> pins exact package versions so production matches local. Deps declared in <code>DESCRIPTION</code>.</p>
+        <div class="files"><span class="file">renv.lock</span><span class="file">DESCRIPTION</span></div>
+      </div>
+      <div class="card">
+        <span class="k">tests · CI</span>
+        <h3>testthat</h3>
+        <p>~40 test files under <code>tests/testthat/</code> — one per drug plus PK, plotting, and helper suites. R-CMD-check runs via GitHub Actions.</p>
+        <div class="files"><span class="file">tests/testthat/</span><span class="file">.github/</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span>stanpumpR · PK/PD simulation · Steven L. Shafer</span>
+    <span>Map generated from <code>master</code> — entry point <code>app.R → run_app()</code></span>
+  </div>
+</footer>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,134 @@
+# stanpumpR — Architecture
+
+A visual version of this map is in [`architecture.html`](architecture.html) (open in a
+browser). This document is the GitHub-rendered equivalent.
+
+stanpumpR is a Shiny web app that turns a table of drug doses plus a patient's covariates into
+predicted **plasma** and **effect-site** concentration curves — using **closed-form**
+pharmacokinetic solutions rather than a numeric ODE solver. It is packaged as a standard R
+package with a golem-style `ui / server / run` split; the entry point is
+`app.R → stanpumpR::run_app()`.
+
+| | |
+|---|---|
+| Language | R (≥ 4.1) |
+| Framework | Shiny + bslib 5 |
+| Structure | R package, ~60 files in `R/` |
+| Drug library | 23 drugs, data-as-code |
+| Deps lock | renv (`renv.lock`) |
+| Config | `config.yml` merged over `DEFAULT_CONFIG` |
+
+## The request → render pipeline
+
+Everything is one reactive dependency chain inside `R/app_server.R`. An edit — a covariate, a
+dose cell, a graph option — invalidates one link, and Shiny re-runs only what is downstream.
+The heavy computation is the last two stages.
+
+```mermaid
+flowchart TD
+    A["<b>01 Inputs</b> — app_ui.R<br/>covariates · dose grid · events · graph options · plot clicks"]
+    B["<b>02 Normalize & validate</b> — server-helpers.R<br/>doseTableClean() · eventTableClean() · testCovariates()"]
+    C["<b>03 Resolve PK</b> — getDrugPK.R<br/>recalculatePK(): covariates → coefficients, per drug"]
+    D["<b>04 Simulate</b> — simCpCe.R<br/>processdoseTable(): re-simulate only changed drugs"]
+    E["<b>05 Assemble plot</b> — simulationPlot.R<br/>build ggplot + allResults / plotResults"]
+    F["<b>06 Render & interact</b> — app_server.R<br/>PlotSimulation · hover · click-to-dose · Suggest · email"]
+    A --> B --> C --> D --> E --> F
+    C -. "drugs() reactive" .- D
+```
+
+Both `recalculatePK()` and `processdoseTable()` mutate a persistent per-drug list and **skip
+any drug whose inputs are unchanged**. Combined with closed-form solutions (no integration), a
+single dose edit re-simulates just the one drug it touched.
+
+### Key reactives (in `app_server.R`)
+
+| Reactive | Role |
+|---|---|
+| `doseTableClean()` / `eventTableClean()` | coerce grids, drop blank rows, convert clock→elapsed time |
+| `testCovariates()` / `weight()` `height()` `age()` `sex()` | validated patient values |
+| `plotInfo()` → `plotMaximum()`, `steps()` | x-axis extent derived from doses/events |
+| `drugs()` | **A:** `recalculatePK()` then **B:** `processdoseTable()` |
+| `simulationPlotRetval()` | calls `simulationPlot()`; exposes `plotObject`, `allResults`, `plotResults`, `plotHeight` |
+
+## The computational core
+
+stanpumpR never numerically integrates. Each drug is a 3-compartment mammillary model with an
+effect-site link; disposition is solved analytically once per patient, then evaluated at every
+time point as a sum of exponentials.
+
+### A — Parameterize the patient (`getDrugPK.R`)
+
+1. `eval(call(drug, weight, height, age, sex))` runs the drug's own covariate model → `v1..v3`, `cl1..cl3`, `tPeak`, `MEAC`.
+2. Volumes & clearances → micro rate constants `k10, k12, k13, k21, k31`.
+3. `cube()` solves the characteristic cubic → eigenvalues `lambda_1, lambda_2, lambda_3`.
+4. `tPeakError()` + `optimize()` back-solve the effect-site rate `ke0` from time-to-peak-effect.
+5. Precompute per-route (bolus / infusion / PO / IM / IN) exponential coefficients `p_coef_*`, `e_coef_*`.
+
+### B — Advance the doses (`simCpCe.R`)
+
+1. Reduce mg/mcg/ng, per-kg, per-hour doses to base units.
+2. Classify each dose as bolus, infusion, or `PO / IM / IN`.
+3. Dispatch to a solver:
+   - `advanceClosedForm0.R` — IV, no PK events
+   - `advanceClosedForm1.R` — time-varying PK driven by events
+   - `advanceClosedFormPO_IM_IN.R` — extravascular routes
+4. Sum each dose's contribution over the exponential basis; `convertState.R` carries state across event boundaries.
+5. Interpolate to an even grid (`equiSpace`), normalize to peak Cp/Ce, and scale against MEAC.
+
+Output per drug: a tidy `Time · Plasma · Effect Site · Recovery` table plus `equiSpace` and `max`.
+
+The exported, Shiny-free entry point for this whole path is
+`simulateDrugsWithCovariates()` (used by the vignettes and tests).
+
+## Drug library — data as code
+
+Adding a drug means one `R/drugs_<name>.R` file plus one row in the defaults CSV. See
+**[adding-a-drug.md](adding-a-drug.md)** for the full procedure.
+
+- **Model** — `R/drugs_*.R` (23 files): each exports `drug(weight, height, age, sex)` returning compartment `PK`, `tPeak`, `MEAC`. Bodies encode published covariate models (often branching on BMI or sex). Invoked by name via `eval(call(drug, ...))`.
+- **Metadata** — `inst/extdata/drugDefaults_global.csv`: colors, units, typical ranges, MEAC, emergence thresholds. Loaded once via memoised `getDrugDefaultsGlobal()`; the `Drug` column *is* the drug list.
+- **Events** — `inst/extdata/eventDefaults.csv`: named clinical events that can switch a drug to alternate PK mid-simulation.
+
+## Component catalog (`R/` by responsibility)
+
+Files are flat in `R/` and wired by the `Collate:` order in `DESCRIPTION`.
+
+**Shell — bootstrap & framework**
+`app.R`, `app_run.R` (`run_app()`), `app_ui.R`, `app_server.R` (the reactive heart),
+`app_globals.R` (init tables, bookmark exclusions, `outputComments()`),
+`globalVariables.R`, `zzz.R`, `stanpumpR-package.R`.
+
+**Reactive glue — server helpers & UI widgets**
+`server-helpers.R` (`recalculatePK`, `cleanDT`, `checkNumericCovariates`), `shiny-utils.R`,
+`createHOT.R` (the `rhandsontable` dose grid), `processdoseTable.R`, `validateDose.R`,
+`validateTime.R`.
+
+**PK/PD engine — the math core**
+`getDrugPK.R`, `cube.R`, `simCpCe.R`, `advanceClosedForm0/1/PO_IM_IN.R`,
+`advanceState.R`, `advanceStatePO.R`, `convertState.R`, `CE.R`, `calculateCe.R`,
+`tPeakError.R`, `modelInteraction.R`, `recoveryCalc.R`, `lbmJames.R`,
+`simulateDrugsWithCovariates.R`.
+
+**Output — plot, dosing advisor & export**
+`simulationPlot.R`, `setLinetypes.R`, `suggest.R` (target-controlled dosing optimizer),
+`sendSlide.R` (renders an `officer` PPTX from `Template.pptx`, emails via `mailR`).
+
+**Util — time & misc**
+`clockTimeToDelta.R`, `deltaToClockTime.R`, `hourMinute.R`, `utils.R`,
+`drugAndEventDefaults.R`.
+
+## Around the core
+
+- **Suggest Dosing** (`suggest.R`) — optimizes bolus + infusion to reach/hold a target concentration.
+- **Email a slide** (`sendSlide.R`) — branded PPTX of the current simulation plus a URL that reconstructs the state.
+- **Editors & modals** — in-app Drug Library and Drug Thresholds editors; click-to-add-dose / double-click-to-edit from plot coordinates.
+- **URL bookmarking** — `enableBookmarking = "url"`; `bookmarksToExclude` keeps transient UI state out of the link.
+- **Debug & profiler** — `?debug=1` reveals a live log (`outputComments`) and a per-reactive profiler (`profileCode`).
+- **Front-end assets** — `inst/www/`: `app.css`, `app.js`, `hot_funs.js` (Handsontable hooks, drug-default injection).
+- **Reproducibility** — `renv.lock` pins package versions; deps declared in `DESCRIPTION`.
+- **Tests / CI** — ~40 files in `tests/testthat/` (one per drug plus PK, plotting, helper suites); R-CMD-check via GitHub Actions.
+
+---
+
+*Generated from `master`. If the code has drifted from this map, update it — it lives with the
+code so it can be kept honest.*


### PR DESCRIPTION
## What

Adds developer-facing documentation. **No code changes** — docs only.

- **`CLAUDE.md`** — orientation for Claude Code sessions: the reactive pipeline, the closed-form (not ODE) PK engine, the drug-library pattern, and repo conventions.
- **`docs/architecture.md`** — human-facing architecture map with a mermaid pipeline diagram (renders on GitHub).
- **`docs/architecture.html`** — standalone visual version of the map (theme-aware, self-contained).
- **`docs/adding-a-drug.md`** — step-by-step contributor guide for adding a drug, grounded in the actual `drugs_*.R` return contract, the `drugDefaults_global.csv` schema, and the `test-drugs-*.R` pattern.

## Why

stanpumpR is an open collaboration that explicitly invites outside investigators to add and maintain drugs, but the repo had no onboarding docs and no `CLAUDE.md`. These capture the two things newcomers struggle with most: the reactive dose-table to plot pipeline and the closed-form 3-compartment engine.

## Notes

- Content was written from reading the code on `master`; it lives in-repo so it can be kept honest as the code evolves.
- While writing the add-a-drug guide I noticed `getDrugPK.R` returns `emerge = drugDefaults$Emerge`, but the CSV has no `Emerge` column (it has `endCe`), so that field resolves to `NULL`. Flagging for possible separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository orientation and development guidance, including setup, testing, architecture, and coding conventions.
  * Added instructions for adding drugs, including model requirements, metadata, testing, and verification.
  * Added comprehensive architecture documentation covering the Shiny workflow, PK/PD calculations, drug library, dosing, exports, bookmarking, and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->