### PR TITLE
docs: comment & provenance conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,12 @@ the `drugs_*.R` file, a CSV row, a `Collate:` entry in `DESCRIPTION`, and a
 
 ## Conventions
 
-- Files are flat in `R/`; load order is the explicit `Collate:` list in `DESCRIPTION` — add
-  new files there.
+- Files are flat in `R/`; load order is the explicit `Collate:` list in `DESCRIPTION`. Because a
+  `Collate:` field is present, **every** file in `R/` must be listed there — an omitted file makes
+  `R CMD build` fail (not just warn). Add new files to `Collate:`, or run `devtools::document()`.
+- **Comments:** favor generous commenting — explain intent and derivation, not only mechanics. For
+  non-obvious, imported, or AI-drafted code, add a **provenance** header recording where it came
+  from (which tool/model or human), the date, and whether it has been run/verified.
 - Use `outputComments(...)` (not `cat`/`print`) for debug logging; wrap costly reactives in
   `profileCode(...)`.
 - New user-facing inputs that should NOT be bookmarked go in `bookmarksToExclude`

--- a/R/ig_absorption.R
+++ b/R/ig_absorption.R
@@ -1,4 +1,13 @@
 # -----------------------------------------------------------------------------
+# Provenance
+# ----------
+# Drafted by Claude Chat (claude.ai), 2026-08-07. Not authored by Claude Code.
+# The underlying mathematics was verified numerically by the authoring model
+# against adaptive quadrature (see STATUS below), but this R transcription has
+# NOT itself been executed end-to-end. Run the verification block at the bottom
+# before relying on any of it. Not yet exported or wired into the simulation
+# engine as of this writing.
+# -----------------------------------------------------------------------------
 # Closed-form convolution of an Inverse Gaussian absorption density with a
 # sum-of-exponentials disposition function.
 #


### PR DESCRIPTION
Two small documentation/comment changes reflecting a preference for heavy commenting and code provenance.

- **`CLAUDE.md`** — adds a convention: favor generous commenting, and for non-obvious, imported, or AI-drafted code include a **provenance** header (origin, author tool/model or human, date, run/verified status). Also clarifies the hard rule we just hit: because `DESCRIPTION` has a `Collate:` field, **every** `R/` file must be listed there or `R CMD build` fails.
- **`R/ig_absorption.R`** — adds a provenance header recording that the file was **drafted by Claude Chat (claude.ai) on 2026-08-07**, not authored by Claude Code, and has not been executed end-to-end.

No functional code change. Does not touch `renv.lock` (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified project contribution and build requirements to help maintain consistency and prevent incomplete package builds.
  * Added guidance for documenting implementation intent, derivation, source information, verification status, and other relevant context.
  * Documented the verification status and integration state of a new internal absorption-related implementation.

* **User Impact**
  * No changes to exported functionality or simulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->