### PR TITLE
chore(deps): bump png 0.1-8 -> 0.1-9 (clears RSEC-2026-1)

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -2887,10 +2887,11 @@
     },
     "png": {
       "Package": "png",
-      "Version": "0.1-8",
+      "Version": "0.1-9",
       "Source": "Repository",
       "Title": "Read and write PNG images",
-      "Author": "Simon Urbanek <Simon.Urbanek@r-project.org>",
+      "Author": "Simon Urbanek [aut, cre, cph] (https://urbanek.nz, ORCID: <https://orcid.org/0000-0003-2297-1732>)",
+      "Authors@R": "person(\"Simon\", \"Urbanek\", role=c(\"aut\",\"cre\",\"cph\"), email=\"Simon.Urbanek@r-project.org\", comment=c(\"https://urbanek.nz\", ORCID=\"0000-0003-2297-1732\"))",
       "Maintainer": "Simon Urbanek <Simon.Urbanek@r-project.org>",
       "Depends": [
         "R (>= 2.9.0)"
@@ -2898,7 +2899,8 @@
       "Description": "This package provides an easy and simple way to read, write and display bitmap images stored in the PNG format. It can read and write both files and in-memory raw vectors.",
       "License": "GPL-2 | GPL-3",
       "SystemRequirements": "libpng",
-      "URL": "http://www.rforge.net/png/",
+      "URL": "https://www.rforge.net/png/",
+      "BugReports": "https://github.com/s-u/png/issues/",
       "NeedsCompilation": "yes",
       "Repository": "CRAN",
       "Encoding": "UTF-8"


### PR DESCRIPTION
Bumps `png` from 0.1-8 to 0.1-9 to clear the single advisory found by an OSV scan of the full lockfile.

**RSEC-2026-1 / CVE-2026-25646** concerns `png` downloading an old libpng (1.5.4) when built **from source on Windows with R < 4.2**. It does **not** apply to this deployment (Linux production, R 4.5.x, where libpng is bundled/system-provided) — but 0.1-9 is the fixed release, so this removes the finding entirely.

Only `png` changes; all other packages unchanged. Follow-up to #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)