### PR TITLE
ci: install full system deps in deploy workflows

### DIFF
--- a/.github/workflows/shiny-deploy-production.yaml
+++ b/.github/workflows/shiny-deploy-production.yaml
@@ -26,7 +26,11 @@ jobs:
           use-public-rspm: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpng-dev
+        # renv restores the full lockfile (incl. dev deps like gert -> libgit2,
+        # rJava -> JDK, systemfonts/ragg -> cairo/freetype). Install the system
+        # libraries these load against so the restore doesn't fail when a package
+        # has no prebuilt binary. Mirrors the R-CMD-check workflow's system deps.
+        run: sudo apt-get update && sudo apt-get install -y cmake default-jdk libcairo2-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libpng-dev libx11-dev
 
       - uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/shiny-pr-2-deploy.yaml
+++ b/.github/workflows/shiny-pr-2-deploy.yaml
@@ -48,7 +48,11 @@ jobs:
           use-public-rspm: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpng-dev
+        # renv restores the full lockfile (incl. dev deps like gert -> libgit2,
+        # rJava -> JDK, systemfonts/ragg -> cairo/freetype). Install the system
+        # libraries these load against so the restore doesn't fail when a package
+        # has no prebuilt binary. Mirrors the R-CMD-check workflow's system deps.
+        run: sudo apt-get update && sudo apt-get install -y cmake default-jdk libcairo2-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libpng-dev libx11-dev
 
       - uses: r-lib/actions/setup-renv@v2
 


### PR DESCRIPTION
Fixes a latent gap in the deploy workflows exposed by #260 (the R 4.6.1 / CRAN update).

## Problem
The PR-preview and production deploy jobs install only `libpng-dev` and rely on every package having a prebuilt Posit Package Manager binary. `setup-renv` restores the **full** lockfile (including dev deps), and after the dependency update, restoring on the runner needs to load packages against system libraries that aren't present -- the preview deploy on #260 failed with:

```
error testing if 'gert' can be loaded
libgit2.so.1.7: cannot open shared object file: No such file or directory
```

## Fix
Install the same system-dependency set the R-CMD-check workflow already uses, in **both** deploy workflows (PR preview + production): `cmake default-jdk libcairo2-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libpng-dev libx11-dev`. Covers gert→libgit2, rJava→JDK, systemfonts/ragg/gdtools→cairo/freetype/fontconfig.

Must land on `master` before #260 can deploy, because `pull_request_target` runs the base-branch workflow. No package or code changes.

Generated with Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by ensuring required system libraries and development tools are installed before restoring the application environment.
  * Updated production and preview deployment workflows to support packages requiring graphics, font, networking, Java, Git, and build-tool dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->