### PR TITLE
docs: note R 4.6.1 target; list ig_absorption.R as experimental

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ devtools::test()   # testthat suite
 Requires a `config.yml` (copy from `config.yml.sample`). Package versions are pinned with
 **renv** — after pulling `renv.lock` changes run `renv::restore()`.
 
+Developed and deployed on **R 4.6.1** with current CRAN package versions (all CRAN, no GitHub
+pins). `DESCRIPTION` still declares the minimum as `R (>= 4.1)`, but CI only exercises the
+current release and one prior (~4.5), so treat 4.6.x as the supported line.
+
 ## The reactive pipeline (all in `R/app_server.R`)
 
 One dependency chain; Shiny re-runs only what an edit invalidates:
@@ -51,6 +55,8 @@ unchanged drugs** — preserve that diffing behavior when editing them.
   - `advanceClosedFormPO_IM_IN.R` (oral / IM / intranasal)
 - `simulateDrugsWithCovariates.R` — exported, Shiny-free multi-drug API (used by vignettes/tests).
 - `modelInteraction.R` — propofol × opioid response surface for the interaction facet.
+- `ig_absorption.R` — **experimental, not yet integrated.** Closed-form Inverse Gaussian
+  absorption model (WIP); not exported or wired into the engine. See its provenance header.
 
 ## Drug library — data as code
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -256,8 +256,8 @@
       R package with a golem-style <code>ui / server / run</code> split.
     </p>
     <dl class="facts">
-      <div class="fact"><dt>Language</dt><dd>R <span>≥ 4.1</span></dd></div>
-      <div class="fact"><dt>Framework</dt><dd>Shiny <span>+ bslib 5</span></dd></div>
+      <div class="fact"><dt>Language</dt><dd>R 4.6.1 <span>min ≥ 4.1</span></dd></div>
+      <div class="fact"><dt>Framework</dt><dd>Shiny <span>+ bslib (Bootstrap 5)</span></dd></div>
       <div class="fact"><dt>Structure</dt><dd>R package <span>~60 files</span></dd></div>
       <div class="fact"><dt>Drug library</dt><dd>23 drugs <span>data-as-code</span></dd></div>
       <div class="fact"><dt>Deps lock</dt><dd>renv <span>renv.lock</span></dd></div>
@@ -591,6 +591,7 @@
           <div class="frow"><span class="fname">CE.R · calculateCe.R · tPeakError.R</span><span class="fdesc">Effect-site concentration and <code>ke0</code> fitting.</span></div>
           <div class="frow"><span class="fname">modelInteraction.R · recoveryCalc.R · lbmJames.R</span><span class="fdesc">Interaction surface, recovery thresholds, body-size scaling.</span></div>
           <div class="frow"><span class="fname">simulateDrugsWithCovariates.R</span><span class="fdesc">Exported multi-drug convenience API (no Shiny).</span></div>
+          <div class="frow"><span class="fname">ig_absorption.R</span><span class="fdesc"><em>Experimental — tracked, not yet integrated.</em> Closed-form Inverse Gaussian absorption model; not exported or wired in.</span></div>
         </div>
       </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,8 +11,8 @@ package with a golem-style `ui / server / run` split; the entry point is
 
 | | |
 |---|---|
-| Language | R (≥ 4.1) |
-| Framework | Shiny + bslib 5 |
+| Language | R — developed/deployed on 4.6.1 (min declared ≥ 4.1) |
+| Framework | Shiny + bslib (Bootstrap 5) |
 | Structure | R package, ~60 files in `R/` |
 | Drug library | 23 drugs, data-as-code |
 | Deps lock | renv (`renv.lock`) |
@@ -108,6 +108,8 @@ Files are flat in `R/` and wired by the `Collate:` order in `DESCRIPTION`.
 `advanceState.R`, `advanceStatePO.R`, `convertState.R`, `CE.R`, `calculateCe.R`,
 `tPeakError.R`, `modelInteraction.R`, `recoveryCalc.R`, `lbmJames.R`,
 `simulateDrugsWithCovariates.R`.
+*Experimental (tracked, not yet integrated):* `ig_absorption.R` — a closed-form Inverse
+Gaussian absorption model; not exported or wired into the engine (see its provenance header).
 
 **Output — plot, dosing advisor & export**
 `simulationPlot.R`, `setLinetypes.R`, `suggest.R` (target-controlled dosing optimizer),


### PR DESCRIPTION
Small documentation refresh after today's forward-port. Docs only, no code.

## Changes
1. **Note the current R/CRAN target.** `CLAUDE.md` and the architecture map facts now record that the project is developed/deployed on **R 4.6.1** with current CRAN versions (all CRAN, no GitHub pins), while noting `DESCRIPTION` still declares the `R (>= 4.1)` minimum and CI exercises only the current release + one prior.
2. **Document `ig_absorption.R` as experimental.** Added it to the PK/PD engine sections of `CLAUDE.md` and the architecture map (both `.md` and `.html`), flagged *experimental — tracked, not yet integrated*, so the new `R/` file isn't undocumented.

Deliberately left `README.md` and the vignettes unchanged (unaffected), and did not raise the `DESCRIPTION` R minimum (a support-policy call, not a doc fix).

Generated with Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported R version information, including the minimum declared version and tested environments.
  * Clarified that the application uses Shiny with bslib Bootstrap 5.
  * Added documentation for an experimental Inverse Gaussian absorption model that is currently not integrated into the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->