### PR TITLE
docs: note R 4.6.x as the supported line in README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Near-term future developments in stanpumpR will include
 5. Create of help and example pages.
 
 ### Setting up locally
-  
+
+Requires R 4.6.x (developed and deployed on 4.6.1). CI exercises the current release and one prior (~4.5); `DESCRIPTION` still declares the minimum as `R (>= 4.1)`, but 4.6.x is the supported line.
+
 1. Clone/download this repository to your local machine
 2. Open the `stanpumpR.Rproj` file in RStudio
 3. Run `renv::restore()` to install all the necessary packages


### PR DESCRIPTION
## Summary
- Adds an R version note to the README's **Setting up locally** section so it carries the same guidance as `CLAUDE.md`.
- States that stanpumpR is developed and deployed on **R 4.6.x** (4.6.1), CI covers the current release plus one prior (~4.5), and `DESCRIPTION` keeps its `R (>= 4.1)` minimum.

## Why
The README previously gave no R version, so a newcomer following it would install the correct pinned packages via `renv::restore()` but not know 4.6.x is the supported line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local setup guidance to recommend R 4.6.x.
  * Documented CI coverage for R 4.6 and approximately R 4.5.
  * Clarified that R 4.1 remains the minimum supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->