### PR TITLE
Fix margin for input group button in shiny-utils

### DIFF
--- a/R/shiny-utils.R
+++ b/R/shiny-utils.R
@@ -43,8 +43,8 @@ inputWithChoices <- function(tag, choices, inputId = NULL, selected = NULL) {
   left: -4px;
   border-radius: 4px !important;
 }
-.input-with-choices .input-group-btn {
-  margin-top: 1px;
+.input-with-choices .input-group-btn .shiny-input-radiogroup .shiny-options-group {
+  margin-top: 0;
 }
 .input-with-choices .input-group-btn .form-group {
   margin-bottom: 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing for input controls with selectable options.
  * Removed unnecessary top spacing from the options container for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->