### PR TITLE
chore: exclude .claude/ from R package build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,4 @@
 ^config\.yml$
 ^config\.yml\.sample$
 ^rsconnect$
+^\.claude$


### PR DESCRIPTION
## Summary
Adds `^\.claude$` to `.Rbuildignore` so `R CMD build` excludes Claude Code's local `.claude/` config directory from the package tarball.

## Why
The `.claude/` directory holds editor/agent config and has no place in the built R package. Without this line it would be bundled into the tarball and trip `R CMD check` NOTEs about non-standard top-level files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded the `.claude` path from R package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->