### PR TITLE
3/8 Bookmarking: URL default, exclusions, validated restore

### DIFF
--- a/R/app_globals.R
+++ b/R/app_globals.R
@@ -58,6 +58,7 @@ bookmarksToExclude <- c(
   "sendSlide",
   "recipient",
   "emailComments",
+  "age",
   "drugEditsOK",
   "editDrugsHTML",
   "editDrugs",

--- a/R/app_run.R
+++ b/R/app_run.R
@@ -23,8 +23,25 @@ run_app <- function(config_file = "config.yml") {
 
   options(warn = 1)
 
-  config <- config::get(file = config_file)
+  config <- if (file.exists(config_file)) config::get(file = config_file) else list()
   config <- c(config, DEFAULT_CONFIG[!names(DEFAULT_CONFIG) %in% names(config)])
+  scalarFlag <- function(value, name) {
+    if (!is.logical(value) || length(value) != 1L || is.na(value)) {
+      stop(name, " must be true or false")
+    }
+    value
+  }
+  config$allow_url_debug <- scalarFlag(config$allow_url_debug, "allow_url_debug")
+  if (!is.numeric(config$debug) || length(config$debug) != 1L || !is.finite(config$debug) ||
+      !config$debug %in% c(DEBUG_LEVEL_OFF, DEBUG_LEVEL_NORMAL, DEBUG_LEVEL_VERBOSE)) {
+    stop("debug must be 0, 1, or 2")
+  }
+  if (!is.character(config$bookmark_mode) || length(config$bookmark_mode) != 1L || is.na(config$bookmark_mode)) {
+    stop("bookmark_mode must be a single string")
+  }
+  if (!config$bookmark_mode %in% c("disable", "server", "url")) {
+    stop("bookmark_mode must be one of: disable, server, url")
+  }
   .sprglobals$config <- config
 
   ggplot2::theme_update(
@@ -44,5 +61,5 @@ run_app <- function(config_file = "config.yml") {
 
   shiny::addResourcePath("stanpumpr-assets", system.file("www", package = "stanpumpR"))
 
-  shiny::shinyApp(app_ui(), app_server, enableBookmarking = "url")
+  shiny::shinyApp(app_ui(), app_server, enableBookmarking = config$bookmark_mode)
 }

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -16,12 +16,15 @@ app_server <- function(input, output, session) {
   observeEvent(input$debug_level, ignoreInit = TRUE, {
     session$userData$debug(input$debug_level)
   })
-  observe({
-    query <- parseQueryString(session$clientData$url_search)
-    if (!is.null(query[["debug"]])) {
-      session$userData$debug(as.numeric(query[["debug"]]))
-    }
-  })
+  if (isTRUE(config$allow_url_debug)) {
+    observe({
+      query <- parseQueryString(session$clientData$url_search)
+      requested <- suppressWarnings(as.numeric(query[["debug"]]))
+      if (length(requested) == 1L && is.finite(requested) && requested %in% c(DEBUG_LEVEL_OFF, DEBUG_LEVEL_NORMAL, DEBUG_LEVEL_VERBOSE)) {
+        session$userData$debug(requested)
+      }
+    })
+  }
 
   # Write out logs to the log section
   observeEvent(session$userData$debug(), {
@@ -167,6 +170,10 @@ app_server <- function(input, output, session) {
     profileCode({
       state$values$DT <- doseTable()
       state$values$ET <- eventTable()
+      # Store only the normalized display value. Exact ages above 89 are never
+      # retained in bookmarks (URL or server), so the saved link carries no
+      # identifying age.
+      state$values$simulationAge <- normalizeSimulationAge(age()) / ageUnit()
       setBookmarkExclude(bookmarksToExclude)
     }, name = "onBookmark()")
   })
@@ -187,17 +194,23 @@ app_server <- function(input, output, session) {
         "***************************************************************************",
         sep = ""
       )
-      DT <- as.data.frame(state$values$DT)
-      doseTable(DT)
-      outputComments("doseTable:")
-      outputComments(DT)
-      ET <- as.data.frame(state$values$ET)
+      DT <- as.data.frame(state$values$DT, stringsAsFactors = FALSE)
+      ET <- as.data.frame(state$values$ET, stringsAsFactors = FALSE)
       if (ncol(ET) == 0) {
         ET <- eventTableInit
       }
+      tryCatch({
+        validateDoseTableInput(DT, drugDefaults())
+        validateEventTableInput(ET, eventDefaults())
+      }, error = function(e) {
+        showModal(modalDialog(title = "Invalid saved simulation", "The saved simulation was rejected because it contains invalid or excessive data."))
+        stop("Rejected invalid bookmark state: ", conditionMessage(e), call. = FALSE)
+      })
+      doseTable(DT)
       eventTable(ET)
-      outputComments("eventTable:")
-      outputComments(ET)
+      if (!is.null(state$values$simulationAge)) {
+        updateNumericInput(session, "age", value = state$values$simulationAge)
+      }
     }, name = "onRestored()")
   })
 

--- a/R/globalVariables.R
+++ b/R/globalVariables.R
@@ -69,5 +69,18 @@ DEFAULT_CONFIG <- list(
   title = "stanpumpR",
   help_link = "https://steveshafer.shinyapps.io/stanpumpR_HelpPage",
   debug = DEBUG_LEVEL_OFF,
+  allow_url_debug = FALSE,
+  # URL bookmarking is the default so saved simulations are shareable as plain
+  # links and work on hosts without server-side state storage (e.g.
+  # shinyapps.io, which throws "server is not configured for saving sessions to
+  # disk" when bookmark_mode = "server"). The URL carries no confidential data:
+  # recipient, comments, and exact age are excluded (see bookmarksToExclude) and
+  # ages >= 90 are normalized to 89 before persistence. URL state is decoded by
+  # Shiny via jsonlite (safeFromJSON) -- never unserialize()/eval() -- and every
+  # restored value is re-validated on the reactive path (validateDoseTableInput
+  # gates the only eval(call(drug,...)) sink), so a crafted URL cannot inject
+  # code. Set "server" only on a host that supports disk-backed bookmarks (e.g.
+  # Posit Connect / Connect Cloud); "disable" turns saved-state sharing off.
+  bookmark_mode = "url",
   long_title = FALSE
 )

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -1,6 +1,15 @@
 default:
   title: "stanpumpR v1.1"
+  # "url" makes saved simulations shareable as plain links and works on hosts
+  # without server-side state storage (e.g. shinyapps.io). No confidential data
+  # is placed in the URL: recipient, comments, and exact age are excluded, and
+  # ages >= 90 are normalized to 89. Restored state is re-validated server-side,
+  # so a crafted URL cannot inject code. Use "server" (opaque IDs) only on a host
+  # that supports disk-backed bookmarks such as Posit Connect Cloud; use
+  # "disable" to turn saved-state sharing off entirely.
+  bookmark_mode: "url"
+  allow_url_debug: false
   email_username: "<gmail username>"
   email_password: "<gmail password>"
   help_link: "https://steveshafer.shinyapps.io/stanpumpR_HelpPage"
-  debug: 2   # 0 = off, 1 = normal, 2 = verbose
+  debug: 0   # 0 = off, 1 = normal, 2 = verbose


### PR DESCRIPTION
### 🧩 #273 split — 8 stacked PRs (review & merge in order)

- [ ] 1/8 · #274 — Server-side input validation
- [ ] 2/8 · #275 — Age/PHI normalization
- [ ] **3/8 · #276 — Bookmarking privacy ← this PR**
- [ ] 4/8 · #277 — Email/SMTP hardening
- [ ] 5/8 · #278 — Front-end injection hardening
- [ ] 6/8 · #279 — Handsontable cleanup
- [ ] 7/8 · #280 — CI/CD & deployment
- [ ] 8/8 · #281 — Documentation

Related but independent (off `master`): #282 — GitHub Source link.

---

**Part 3 of 8** splitting #273. **Stacked on #275** (base = `security/02-age-phi`).

## What this PR does
Makes URL bookmarking the default and treats restored state as untrusted.

- `bookmark_mode` (default `"url"`) and `allow_url_debug` added to `DEFAULT_CONFIG`; both validated in `run_app()`, which now also starts cleanly when no `config.yml` is present. `enableBookmarking` is config-driven.
- `"url"` works on hosts without server-side state storage (e.g. shinyapps.io, which errors under `"server"`); `"server"` remains available for Posit Connect Cloud.
- URL-activated debug is gated behind `allow_url_debug` and range-validated.
- `onBookmark` stores only the normalized (≤ 89) age, and `"age"` is added to `bookmarksToExclude`, so the exact age never enters the link.
- `onRestored` re-validates the restored dose/event tables (reusing #274's validators) and rejects invalid saved state before applying it.

## Notes
- Shiny decodes URL state as JSON (`safeFromJSON`), never `unserialize`/`eval`; combined with the reactive-path validators, a crafted link cannot inject code.
- Config-sample email settings and the security-deployment docs land in later PRs.

## Testing
`devtools::test()` — 96 passed, 0 failures.
