### PR TITLE
4/8 Email/SMTP hardening (curl transport, env-var creds, PHI guards)

### DIFF
--- a/.Renviron.example
+++ b/.Renviron.example
@@ -1,0 +1,9 @@
+# Copy these names to your user-level ~/.Renviron and replace the examples.
+# Never put real credentials in this project directory.
+STANPUMPR_EMAIL_USERNAME=stanpumpr@example.com
+STANPUMPR_EMAIL_PASSWORD=replace-with-google-app-password
+STANPUMPR_EMAIL_ENABLED=true
+# Optional overrides; these are the defaults shown here.
+STANPUMPR_EMAIL_SMTP_HOST=smtp.gmail.com
+STANPUMPR_EMAIL_SMTP_PORT=587
+STANPUMPR_EMAIL_SMTP_SSL=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,10 @@ Authors@R:
 Description: stanpumpR is open-source software for pharmacokinetic / pharmacodynamic simulation. It is intended to make pharmacokinetics accessible to facilitate perioperative patient care, teaching, and research. stanpumpR may be freely downloaded and used without restriction for non-commericial purposes.
 License: MIT + file LICENSE
 Imports:
+  base64enc,
   bslib,
   config,
+  curl,
   dplyr,
   glue,
   ggplot2  (>= 3.4),
@@ -24,7 +26,6 @@ Imports:
   jsonlite,
   lubridate,
   magrittr,
-  mailR,
   memoise,
   officer,
   openxlsx,

--- a/R/app_run.R
+++ b/R/app_run.R
@@ -25,6 +25,27 @@ run_app <- function(config_file = "config.yml") {
 
   config <- if (file.exists(config_file)) config::get(file = config_file) else list()
   config <- c(config, DEFAULT_CONFIG[!names(DEFAULT_CONFIG) %in% names(config)])
+  # Credentials must come from the process environment, not config.yml. An
+  # empty environment variable intentionally does not fall back to plaintext
+  # configuration, preventing accidental secret deployment in an app bundle.
+  config$email_username <- Sys.getenv("STANPUMPR_EMAIL_USERNAME", unset = "")
+  config$email_password <- Sys.getenv("STANPUMPR_EMAIL_PASSWORD", unset = "")
+  envFlag <- function(name, fallback) {
+    value <- Sys.getenv(name, unset = "")
+    if (!nzchar(value)) return(fallback)
+    normalized <- tolower(trimws(value))
+    if (!normalized %in% c("true", "false")) stop(name, " must be true or false")
+    identical(normalized, "true")
+  }
+  envText <- function(name, fallback) {
+    value <- Sys.getenv(name, unset = "")
+    if (nzchar(value)) value else fallback
+  }
+  envPort <- Sys.getenv("STANPUMPR_EMAIL_SMTP_PORT", unset = "")
+  config$email_enabled <- envFlag("STANPUMPR_EMAIL_ENABLED", config$email_enabled)
+  config$email_smtp_ssl <- envFlag("STANPUMPR_EMAIL_SMTP_SSL", config$email_smtp_ssl)
+  config$email_smtp_host <- envText("STANPUMPR_EMAIL_SMTP_HOST", config$email_smtp_host)
+  if (nzchar(envPort)) config$email_smtp_port <- suppressWarnings(as.numeric(envPort))
   scalarFlag <- function(value, name) {
     if (!is.logical(value) || length(value) != 1L || is.na(value)) {
       stop(name, " must be true or false")
@@ -32,6 +53,8 @@ run_app <- function(config_file = "config.yml") {
     value
   }
   config$allow_url_debug <- scalarFlag(config$allow_url_debug, "allow_url_debug")
+  config$email_enabled <- scalarFlag(config$email_enabled, "email_enabled")
+  config$email_smtp_ssl <- scalarFlag(config$email_smtp_ssl, "email_smtp_ssl")
   if (!is.numeric(config$debug) || length(config$debug) != 1L || !is.finite(config$debug) ||
       !config$debug %in% c(DEBUG_LEVEL_OFF, DEBUG_LEVEL_NORMAL, DEBUG_LEVEL_VERBOSE)) {
     stop("debug must be 0, 1, or 2")
@@ -41,6 +64,17 @@ run_app <- function(config_file = "config.yml") {
   }
   if (!config$bookmark_mode %in% c("disable", "server", "url")) {
     stop("bookmark_mode must be one of: disable, server, url")
+  }
+  if (isTRUE(config$email_enabled)) {
+    requiredEmailConfig <- c("email_username", "email_password", "email_smtp_host")
+    missingEmailConfig <- requiredEmailConfig[vapply(requiredEmailConfig, function(x) {
+      is.null(config[[x]]) || length(config[[x]]) != 1L || !nzchar(config[[x]])
+    }, logical(1))]
+    invalidPort <- !is.numeric(config$email_smtp_port) || length(config$email_smtp_port) != 1L ||
+      !is.finite(config$email_smtp_port) || config$email_smtp_port < 1 || config$email_smtp_port > 65535
+    if (length(missingEmailConfig) > 0L || invalidPort) {
+      stop("Email is enabled but its credentials or SMTP configuration is incomplete.")
+    }
   }
   .sprglobals$config <- config
 

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -568,7 +568,11 @@ app_server <- function(input, output, session) {
   })
 
   observe({
-    shinyjs::toggleState("sendSlide", condition = isEmailValid(input$recipient))
+    shinyjs::toggleState(
+      "sendSlide",
+      condition = isTRUE(config$email_enabled) &&
+        isEmailRecipientValid(input$recipient)
+    )
   })
 
   # Send Slide -----------------------------
@@ -577,15 +581,25 @@ app_server <- function(input, output, session) {
     {
       outputComments("input$sendSlide",input$sendSlide)
 
+      if (!isTRUE(config$email_enabled)) {
+        shinyalert::shinyalert("Email disabled", "Email export is disabled for this deployment.", type = "error")
+        return()
+      }
+
       # Server-side guard: the send button's disabled state is enforced only in
       # the browser and can be bypassed by sending the event over the WebSocket,
       # so the recipient MUST be validated here before any mail is sent.
-      if (!isTRUE(isEmailValid(input$recipient))) {
+      if (!isEmailRecipientValid(input$recipient)) {
         shinyalert::shinyalert(
           "Invalid email address",
-          "Please enter a valid recipient email address.",
+          "Enter a valid recipient email address.",
           type = "error", closeOnClickOutside = TRUE
         )
+        return()
+      }
+
+      if (length(input$emailComments) != 1L || nchar(input$emailComments, type = "bytes") > MAX_INPUT_TEXT) {
+        shinyalert::shinyalert("Comments too long", "Email comments exceed the permitted length.", type = "error")
         return()
       }
 
@@ -627,7 +641,10 @@ app_server <- function(input, output, session) {
           drugs = drugs(),
           drugDefaults = drugDefaults(),
           email_username = config$email_username,
-          email_password = config$email_password
+          email_password = config$email_password,
+          smtp_host = config$email_smtp_host,
+          smtp_port = config$email_smtp_port,
+          smtp_ssl = config$email_smtp_ssl
         ) |> profileCode("sendSlide()")
       shinycssloaders::hidePageSpinner()
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -210,11 +210,21 @@ app_ui <- function() {
               ),
 
               bslib::accordion_panel(
-                "Email Slide",
+                "Email Simulation",
                 icon = icon("envelope"),
-                textInput("recipient", NULL, "", placeholder = "Enter email address"),
-                textAreaInput("emailComments", NULL, "", placeholder = "Comments (optional)", rows = 3),
-                actionButton("sendSlide", "Send", class = "btn-primary")
+                if (!isTRUE(config$email_enabled)) {
+                  div(
+                    class = "alert alert-secondary py-2 small",
+                    "Email sending is not configured for this deployment."
+                  )
+                },
+                textInput("recipient", NULL, "", placeholder = "Enter recipient email address"),
+                textAreaInput(
+                  "emailComments", NULL, "",
+                  placeholder = "Do not enter any protected health information (PHI).",
+                  rows = 3
+                ),
+                actionButton("sendSlide", "Send Simulation", class = "btn-primary")
               )
             ),
 

--- a/R/globalVariables.R
+++ b/R/globalVariables.R
@@ -82,5 +82,9 @@ DEFAULT_CONFIG <- list(
   # code. Set "server" only on a host that supports disk-backed bookmarks (e.g.
   # Posit Connect / Connect Cloud); "disable" turns saved-state sharing off.
   bookmark_mode = "url",
+  email_enabled = FALSE,
+  email_smtp_host = "smtp.gmail.com",
+  email_smtp_port = 587,
+  email_smtp_ssl = TRUE,
   long_title = FALSE
 )

--- a/R/sendSlide.R
+++ b/R/sendSlide.R
@@ -11,14 +11,17 @@ sendSlide <- function(
   drugs,
   drugDefaults,
   email_username,
-  email_password
+  email_password,
+  smtp_host = "smtp.gmail.com",
+  smtp_port = 587,
+  smtp_ssl = TRUE
 )
 {
-  tryCatchLog::tryCatchLog({
+  tryCatch({
     prevEcho <- options("ECHO_OUTPUT_COMMENTS" = TRUE)
     on.exit(options("ECHO_OUTPUT_COMMENTS" = prevEcho[[1]]))
 
-    outputComments("Sending email to", recipient)
+    outputComments("Preparing simulation email")
 
     if (missing(email_username) || is.null(email_username)) {
       stop("email username missing")
@@ -27,47 +30,110 @@ sendSlide <- function(
       stop("email password missing")
     }
 
-    emailData <- generateEmail(values, recipient, plotObject, allResults, plotResults, height, width, slide, drugs, drugDefaults)
+    outputDir <- tempfile(pattern = "stanpumpr-email-")
+    dir.create(outputDir, mode = "0700")
+    on.exit(unlink(outputDir, recursive = TRUE, force = TRUE), add = TRUE)
+
+    emailData <- generateEmail(
+      values, recipient, plotObject, allResults, plotResults, height, width,
+      slide, drugs, drugDefaults, outputDir = outputDir
+    )
 
     outputComments("Sending email")
-    email <- mailR::send.mail(
-      from = paste0("stanpumpR <", email_username, ">"),
+    message <- createSimulationEmailMessage(
+      from = email_username,
       to = recipient,
       subject = emailData$title,
-      body = emailData$bodyText,
-      html = TRUE,
-      smtp = list(
-        host.name = "smtp.gmail.com",
-        port = 587,
-        user.name = email_username,
-        passwd = email_password,
-        ssl = TRUE),
-      attach.files = c(
+      html = emailData$bodyText,
+      attachments = c(
         emailData$pptxfileName,
         emailData$pngfileName,
         emailData$xlsxfileName
-      ),
-      authenticate = TRUE
+      )
     )
-    unlink(emailData$pptxfileName)
-    unlink(emailData$pngfileName)
-    unlink(emailData$xlsxfileName)
+    smtpScheme <- if (isTRUE(smtp_ssl) && smtp_port == 465) "smtps" else "smtp"
+    curl::send_mail(
+      mail_from = email_username,
+      mail_rcpt = recipient,
+      message = message,
+      smtp_server = sprintf("%s://%s:%d", smtpScheme, smtp_host, smtp_port),
+      use_ssl = if (isTRUE(smtp_ssl)) "force" else "no",
+      username = email_username,
+      password = email_password,
+      verbose = FALSE
+    )
     outputComments("Leaving sendMail()")
     return(TRUE)
   }, error = function(e) {
-    return(e$message)
+    # SMTP/library exceptions can contain internal host, account, or transport
+    # details. Do not log the exception or return it to a client.
+    return("The simulation email could not be sent. Please try again later.")
   })
 }
 
-generateEmail <- function(values, recipient, plotObject, allResults, plotResults, height, width, slide, drugs, drugDefaults) {
-  title <- paste("stanpumpR simulation on", format(Sys.time()))
+createSimulationEmailMessage <- function(from, to, subject, html, attachments) {
+  if (!isEmailRecipientValid(from) || !isEmailRecipientValid(to)) {
+    stop("Invalid email header address.")
+  }
+  if (!is.character(subject) || length(subject) != 1L || grepl("[\r\n]", subject)) {
+    stop("Invalid email subject.")
+  }
+  if (!all(file.exists(attachments))) stop("Email attachment missing.")
+
+  boundary <- paste0("stanpumpr-", paste(sample(c(letters, 0:9), 32L, TRUE), collapse = ""))
+  wrapBase64 <- function(x) paste(strwrap(x, width = 76L), collapse = "\r\n")
+  encodeFile <- function(path) {
+    raw <- readBin(path, what = "raw", n = file.info(path)$size)
+    wrapBase64(base64enc::base64encode(raw))
+  }
+  mimeTypes <- c(
+    pptx = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    png = "image/png",
+    xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  )
+  parts <- c(
+    paste0(
+      "--", boundary, "\r\n",
+      "Content-Type: text/html; charset=UTF-8\r\n",
+      "Content-Transfer-Encoding: base64\r\n\r\n",
+      wrapBase64(base64enc::base64encode(charToRaw(enc2utf8(html)))), "\r\n"
+    ),
+    vapply(attachments, function(path) {
+      ext <- tolower(tools::file_ext(path))
+      mime <- unname(mimeTypes[[ext]])
+      if (is.null(mime)) mime <- "application/octet-stream"
+      filename <- basename(path)
+      paste0(
+        "--", boundary, "\r\n",
+        "Content-Type: ", mime, "; name=\"", filename, "\"\r\n",
+        "Content-Disposition: attachment; filename=\"", filename, "\"\r\n",
+        "Content-Transfer-Encoding: base64\r\n\r\n",
+        encodeFile(path), "\r\n"
+      )
+    }, character(1)),
+    paste0("--", boundary, "--\r\n")
+  )
+  paste0(
+    "From: stanpumpR <", from, ">\r\n",
+    "To: ", to, "\r\n",
+    "Subject: ", subject, "\r\n",
+    "MIME-Version: 1.0\r\n",
+    "Content-Type: multipart/mixed; boundary=\"", boundary, "\"\r\n\r\n",
+    paste(parts, collapse = "")
+  )
+}
+
+generateEmail <- function(values, recipient, plotObject, allResults, plotResults, height, width, slide, drugs, drugDefaults,
+                          outputDir) {
+  title <- paste("stanpumpR SIMULATION (not a patient record) on", format(Sys.time()))
   DT <- values$DT
   url <- values$url
 
   outputComments("In function sendSlide()")
 
-  if (!file.exists("Slides")) dir.create("Slides")
-  TIMESTAMP <- format(Sys.time(), format = "%y%m%d-%H%M%S")
+  if (missing(outputDir) || !is.character(outputDir) || length(outputDir) != 1L || !dir.exists(outputDir)) {
+    stop("A private export directory must be supplied.")
+  }
   DATE <- format(Sys.Date(), "%m/%d/%y")
   outputComments("reading Template.pptx")
   PPTX <- officer::read_pptx(system.file("extdata", "Template.pptx", package = "stanpumpR"))
@@ -80,19 +146,23 @@ generateEmail <- function(values, recipient, plotObject, allResults, plotResults
 
   PPTX <- officer::ph_with(PPTX, DATE, location = officer::ph_location_type ("dt"))
   PPTX <- officer::ph_with(PPTX, slide, location = officer::ph_location_type ("sldNum"))
-  PPTX <- officer::ph_with(PPTX, "From StanpumpR", location = officer::ph_location_type ("ftr"))
-  pptxfileName <- paste0("Slides/From stanpumpR.", slide, ".", TIMESTAMP, ".pptx")
+  PPTX <- officer::ph_with(
+    PPTX, "stanpumpR SIMULATION — NOT A PATIENT RECORD",
+    location = officer::ph_location_type("ftr")
+  )
+  pptxfileName <- file.path(outputDir, "stanpumpR-simulation.pptx")
 
   outputComments("Saving PPTX")
   print(PPTX, target = pptxfileName)
 
-  xlsxfileName <- paste0("Slides/From stanpumpR.", slide, ".", TIMESTAMP, ".xlsx")
+  xlsxfileName <- file.path(outputDir, "stanpumpR-simulation.xlsx")
 
   outputComments("Creating PNG file")
 
-  pngfileName <- paste0("Slides/Preview.", slide, ".", TIMESTAMP, ".png")
+  pngfileName <- file.path(outputDir, "stanpumpR-preview.png")
   ggplot2::ggsave(
     plotObject +
+      ggplot2::labs(caption = "stanpumpR SIMULATION — NOT A PATIENT RECORD") +
       ggplot2::theme(
         strip.text.y = ggplot2::element_text(size = 6, angle = 180),
         axis.text.y = ggplot2::element_text(size = 6),
@@ -157,6 +227,10 @@ generateEmail <- function(values, recipient, plotObject, allResults, plotResults
   outputComments("Writing covariates")
   openxlsx::addWorksheet(wb, "Covariates")
   openxlsx::writeData(wb, sheet = 1, covariates)
+  openxlsx::writeData(
+    wb, sheet = 1, x = "stanpumpR SIMULATION — NOT A PATIENT RECORD",
+    startCol = 4, startRow = 1
+  )
 
   outputComments("Writing dose table")
   openxlsx::addWorksheet(wb, "Dose Table")
@@ -274,6 +348,7 @@ generateEmail <- function(values, recipient, plotObject, allResults, plotResults
     "<body><div>",
     "<p>&nbsp;</p>",
     "<p>Dear ",htmltools::htmlEscape(gsub("@", " at ",as.character(recipient))),":<p>&nbsp;</p>",
+    "<p><strong>SIMULATION — NOT A PATIENT RECORD</strong></p><p>&nbsp;</p>",
     "<p>Here is the simulation you requested from stanpumpR on ", Sys.Date(),".</p><p>&nbsp;</p>",
     "<p>The simulation is for a ",values$age / values$ageUnit, " ", ageUnit, "-old ",htmltools::htmlEscape(values$sex),
     " weighing ", values$weight / values$weightUnit, " ",weightUnit,

--- a/R/server-helpers.R
+++ b/R/server-helpers.R
@@ -128,6 +128,11 @@ normalizeSimulationAge <- function(age) {
   min(age, DEIDENTIFIED_MAX_AGE)
 }
 
+isEmailRecipientValid <- function(email) {
+  is.character(email) && length(email) == 1L && !is.na(email) &&
+    nchar(email, type = "bytes") <= 254L && isTRUE(isEmailValid(email))
+}
+
 recalculatePK <- function(drugs, drugDefaults, doseTable,
                           age, weight, height, sex) {
   #  for (idx in seq(nrow(drugDefaults))) {

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -9,7 +9,12 @@ default:
   # "disable" to turn saved-state sharing off entirely.
   bookmark_mode: "url"
   allow_url_debug: false
-  email_username: "<gmail username>"
-  email_password: "<gmail password>"
+  # May be overridden by STANPUMPR_EMAIL_ENABLED in managed deployments.
+  email_enabled: false
+  email_smtp_host: "smtp.gmail.com"
+  email_smtp_port: 587
+  email_smtp_ssl: true
+  # Credentials and optional SMTP overrides use STANPUMPR_EMAIL_* environment
+  # variables. Never put credentials in this file.
   help_link: "https://steveshafer.shinyapps.io/stanpumpR_HelpPage"
   debug: 0   # 0 = off, 1 = normal, 2 = verbose

--- a/renv.lock
+++ b/renv.lock
@@ -2338,30 +2338,6 @@
       "Maintainer": "Lionel Henry <lionel@posit.co>",
       "Repository": "CRAN"
     },
-    "mailR": {
-      "Package": "mailR",
-      "Version": "0.8",
-      "Source": "Repository",
-      "Type": "Package",
-      "Title": "A Utility to Send Emails from R",
-      "Description": "Interface to Apache Commons Email to send emails from R.",
-      "Date": "2021-11-05",
-      "Author": "Rahul Premraj",
-      "Maintainer": "Rahul Premraj <r.premraj+mailR@gmail.com>",
-      "License": "GPL-3",
-      "Imports": [
-        "rJava",
-        "stringr",
-        "R.utils",
-        "assertthat"
-      ],
-      "SystemRequirements": "Java",
-      "URL": "https://github.com/rpremrajGit/mailR",
-      "RoxygenNote": "7.1.2",
-      "Encoding": "UTF-8",
-      "NeedsCompilation": "no",
-      "Repository": "CRAN"
-    },
     "memoise": {
       "Package": "memoise",
       "Version": "2.0.1",
@@ -3207,27 +3183,6 @@
       "Author": "Hadley Wickham [aut, cre] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Lionel Henry [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Hadley Wickham <hadley@posit.co>",
       "Repository": "CRAN"
-    },
-    "rJava": {
-      "Package": "rJava",
-      "Version": "1.0-18",
-      "Source": "Repository",
-      "Title": "Low-Level R to Java Interface",
-      "Author": "Simon Urbanek [aut, cre, cph] (https://urbanek.nz, ORCID: <https://orcid.org/0000-0003-2297-1732>)",
-      "Maintainer": "Simon Urbanek <Simon.Urbanek@r-project.org>",
-      "Authors@R": "person(\"Simon\", \"Urbanek\", role=c(\"aut\",\"cre\",\"cph\"), email=\"Simon.Urbanek@r-project.org\", comment=c(\"https://urbanek.nz\", ORCID=\"0000-0003-2297-1732\"))",
-      "Depends": [
-        "R (>= 3.6.0)",
-        "methods"
-      ],
-      "Description": "Low-level interface to Java VM very much like .C/.Call and friends. Allows creation of objects, calling methods and accessing fields.",
-      "License": "LGPL-2.1",
-      "URL": "https://www.rforge.net/rJava/",
-      "SystemRequirements": "Java JDK 1.2 or higher (for JRI/REngine JDK 1.4 or higher), GNU make",
-      "BugReports": "https://github.com/s-u/rJava/issues",
-      "NeedsCompilation": "yes",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
     },
     "ragg": {
       "Package": "ragg",

--- a/tests/testthat/test-sendSlide.R
+++ b/tests/testthat/test-sendSlide.R
@@ -18,4 +18,44 @@ test_that("it generates the email body", {
   expect_match(bodyText, "The simulation is for a 600 months-old F weighing 150 pounds and 67 inches tall")
   expect_match(bodyText, "file from <a href=\"http://example.com\">stanpumpR</a>")
   expect_match(bodyText, "Thank you for using stanpumpR")
+  expect_match(bodyText, "SIMULATION — NOT A PATIENT RECORD")
+})
+
+test_that("email comments and bookmark attributes are escaped", {
+  values <- list(age = 50, ageUnit = 1, weight = 70, weightUnit = 1,
+                 height = 170, heightUnit = 1, sex = "<script>")
+  body <- generateBodyText(
+    "doctor@hospital.example", values, "years", "kg", "cm",
+    "https://example.test/state?id=&quot;bad", "<img src=x onerror=alert(1)>"
+  )
+  expect_false(grepl("<script>|<img", body))
+  expect_match(body, "&lt;script&gt;")
+  expect_match(body, "&lt;img")
+})
+
+test_that("send failures do not expose SMTP details", {
+  result <- sendSlide(
+    values = list(), recipient = "doctor@example.com", plotObject = NULL,
+    allResults = NULL, plotResults = NULL, height = 400, width = 600,
+    slide = 1, drugs = list(), drugDefaults = data.frame(),
+    email_username = NULL, email_password = NULL
+  )
+  expect_identical(result, "The simulation email could not be sent. Please try again later.")
+})
+
+test_that("simulation email messages contain HTML and attachments", {
+  attachment <- tempfile(fileext = ".png")
+  writeBin(charToRaw("test attachment"), attachment)
+  on.exit(unlink(attachment))
+  message <- createSimulationEmailMessage(
+    "sender@example.com", "recipient@gmail.com", "stanpumpR simulation",
+    "<p>SIMULATION</p>", attachment
+  )
+  expect_match(message, "multipart/mixed", fixed = TRUE)
+  expect_match(message, "Content-Disposition: attachment", fixed = TRUE)
+  expect_false(grepl("<p>SIMULATION</p>", message, fixed = TRUE))
+  expect_error(
+    createSimulationEmailMessage("sender@example.com", "bad\r\nBcc:x@example.com", "x", "x", attachment),
+    "Invalid email header"
+  )
 })

--- a/tests/testthat/test-server-helpers.R
+++ b/tests/testthat/test-server-helpers.R
@@ -54,6 +54,13 @@ test_that("simulation ages 90 and older are normalized to 89", {
   expect_error(normalizeSimulationAge(NA_real_), "finite")
 })
 
+test_that("email recipients may use any valid domain", {
+  expect_true(isEmailRecipientValid("doctor@hospital.example"))
+  expect_true(isEmailRecipientValid("clinician@gmail.com"))
+  expect_false(isEmailRecipientValid("not-an-email"))
+  expect_false(isEmailRecipientValid(c("one@example.com", "two@example.com")))
+})
+
 test_that("target tables are bounded and numeric", {
   valid <- data.frame(Time = "10", Target = 2)
   expect_true(validateTargetTableInput(valid))


### PR DESCRIPTION
### 🧩 #273 split — 8 stacked PRs (review & merge in order)

- [ ] 1/8 · #274 — Server-side input validation
- [ ] 2/8 · #275 — Age/PHI normalization
- [ ] 3/8 · #276 — Bookmarking privacy
- [ ] **4/8 · #277 — Email/SMTP hardening ← this PR**
- [ ] 5/8 · #278 — Front-end injection hardening
- [ ] 6/8 · #279 — Handsontable cleanup
- [ ] 7/8 · #280 — CI/CD & deployment
- [ ] 8/8 · #281 — Documentation

Related but independent (off `master`): #282 — GitHub Source link.

---

**Part 4 of 8** splitting #273. **Stacked on #276** (base = `security/03-bookmarking`).

## What this PR does
Replaces the Java-dependent `mailR`/`rJava` mail path with a `curl` SMTP implementation and hardens the send trust boundary.

- **Transport** (`sendSlide.R`): `curl` SMTP with forced TLS, hand-built MIME multipart, From/To/Subject header-injection rejection, concealed transport errors, no recipient logging, private temp files cleaned up on success or failure.
- **Dependencies**: `DESCRIPTION` drops `mailR`, adds `curl` + `base64enc`; `renv.lock` updated (the `rJava`/`mailR` tree is removed).
- **Credentials/config**: read only from `STANPUMPR_EMAIL_*` env vars (no `config.yml` fallback); email disabled by default; SMTP host/port/ssl configurable; `run_app()` validates email config when enabled.
- **Send guard** (`app_server.R`): `email_enabled` + `isEmailRecipientValid` + comment-length cap enforced server-side before any mail is sent (the browser's disabled button is not a boundary).
- **UI** (`app_ui.R`): "not configured" notice when disabled; PHI warning on the comment field.
- **Tests**: recipient validator + MIME/header handling (`test-sendSlide.R`, `test-server-helpers.R`).

## Testing
`devtools::test()` — 109 passed, 0 failures.
