### PR TITLE
5/8 Front-end injection hardening (referrer, noopener, inline-script escaping)

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -1,5 +1,10 @@
 app_ui <- function() {
-  js_drug_defaults <- paste0("var drug_defaults=", jsonlite::toJSON(stanpumpR::getDrugDefaultsGlobal()))
+  drug_defaults_json <- jsonlite::toJSON(stanpumpR::getDrugDefaultsGlobal())
+  # Prevent a future metadata value containing "</script>" from terminating the
+  # inline script element. The data is trusted today, but this keeps that true
+  # even if defaults later become administrator-editable.
+  drug_defaults_json <- gsub("<", "\\\\u003c", drug_defaults_json, fixed = TRUE)
+  js_drug_defaults <- paste0("var drug_defaults=", drug_defaults_json)
   config <- .sprglobals$config
 
   stanpumpr_theme <- bslib::bs_theme(
@@ -40,6 +45,7 @@ app_ui <- function() {
             "frame-ancestors 'none'"
           )
         ),
+        tags$meta(name = "referrer", content = "no-referrer"),
         shinyjs::useShinyjs(),
         tags$script(src = "stanpumpr-assets/app.js"),
         tags$script(HTML(js_drug_defaults)),
@@ -339,7 +345,8 @@ app_ui <- function() {
           icon("circle-info"),
           "Examples and Help",
           href = config$help_link,
-          target = "_blank"
+          target = "_blank",
+          rel = "noopener noreferrer"
         )
       )
     )


### PR DESCRIPTION
### 🧩 #273 split — 8 stacked PRs (review & merge in order)

- [ ] 1/8 · #274 — Server-side input validation
- [ ] 2/8 · #275 — Age/PHI normalization
- [ ] 3/8 · #276 — Bookmarking privacy
- [ ] 4/8 · #277 — Email/SMTP hardening
- [ ] **5/8 · #278 — Front-end injection hardening ← this PR**
- [ ] 6/8 · #279 — Handsontable cleanup
- [ ] 7/8 · #280 — CI/CD & deployment
- [ ] 8/8 · #281 — Documentation

Related but independent (off `master`): #282 — GitHub Source link.

---

**Part 5 of 8** splitting #273. **Stacked on #277** (base = `security/04-email`).

## What this PR does
Small defense-in-depth hardening of the page `<head>`. Note the Content-Security-Policy `<meta>` **already exists on `master`**; this PR does not add it.

- `<meta name="referrer" content="no-referrer">` — bookmarked URLs can carry simulation state, so suppress the `Referer` header.
- `rel="noopener noreferrer"` on the external "Examples and Help" link.
- Escape `<` → `<` in the inline drug-defaults JSON, so a future metadata value containing `</script>` cannot terminate the inline `<script>` element (data is trusted today; this keeps it safe if defaults later become editable).

## Testing
`devtools::load_all()` clean; full suite unchanged from #277 (109 passed).
