### PR TITLE
6/8 Handsontable: namespace-qualify calls; document sanitization

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -1007,7 +1007,7 @@ app_server <- function(input, output, session) {
         unlist()
       editPriorDosesTable$Delete <- FALSE
 
-      editPriorDosesTableHOT <- rhandsontable(
+      editPriorDosesTableHOT <- rhandsontable::rhandsontable(
         editPriorDosesTable[ , c("Delete","Time","Dose","Units")],
         overflow = 'visible',
         rowHeaders = NULL,
@@ -1160,7 +1160,7 @@ app_server <- function(input, output, session) {
     if (hasEvents) {
       tempTable <- tempTable[,c("Time", "Event")]
       tempTable$Delete <- FALSE
-      tempTableHOT <- rhandsontable(
+      tempTableHOT <- rhandsontable::rhandsontable(
         tempTable[,c("Delete","Time","Event")],
         overflow = 'visible',
         rowHeaders = NULL,
@@ -1282,7 +1282,7 @@ app_server <- function(input, output, session) {
           Time = rep("",6),
           Target = rep("", 6)
         )
-        targetHOT <- rhandsontable(
+        targetHOT <- rhandsontable::rhandsontable(
           targetTable,
           overflow = 'visible',
           rowHeaders = NULL,
@@ -1447,7 +1447,7 @@ app_server <- function(input, output, session) {
       x$Units <- drugUnitsSimplify(x$Units)
       # endCe is managed via the Drug Thresholds modal
       x <- x[, !names(x) %in% "endCe"]
-      drugsHOT <- rhandsontable(
+      drugsHOT <- rhandsontable::rhandsontable(
         x,
         overflow = 'visible',
         rowHeaders = NULL,
@@ -1561,7 +1561,7 @@ app_server <- function(input, output, session) {
     drugThresholdsTrigger$depend()
     x <- drugDefaults()[, c("Drug", "endCe")]
     names(x)[2] <- "Threshold"
-    rhandsontable(x, overflow = 'visible', rowHeaders = NULL, height = 350) %>%
+    rhandsontable::rhandsontable(x, overflow = 'visible', rowHeaders = NULL, height = 350) %>%
       hot_col(col = 1, halign = "htLeft", readOnly = TRUE) %>%
       hot_col(col = 2, halign = "htRight", type = "numeric") %>%
       hot_table(contextMenu = FALSE)

--- a/R/shiny-utils.R
+++ b/R/shiny-utils.R
@@ -8,6 +8,11 @@ inlineUI <- function(tag) {
 
 nbsp <- shiny::HTML("&nbsp;", .noWS = "outside")
 
+# The dose/event/target/drug grids use the Handsontable 6.2.2 build bundled with
+# rhandsontable 0.3.8 (the last MIT-licensed Handsontable release). The client-side
+# key-filtering and input-sanitizing hooks in addHotHooks() (hookFilterKeys /
+# hookSanitize, defined in inst/www/hot_funs.js) plus the server-side validators
+# in server-helpers.R remain the defense-in-depth layer over this grid.
 addHotHooks <- function(hot, filterKeys = TRUE, sanitize = TRUE, ...) {
   hooks <- list(...)
 


### PR DESCRIPTION
### 🧩 #273 split — 8 stacked PRs (review & merge in order)

- [ ] 1/8 · #274 — Server-side input validation
- [ ] 2/8 · #275 — Age/PHI normalization
- [ ] 3/8 · #276 — Bookmarking privacy
- [ ] 4/8 · #277 — Email/SMTP hardening
- [ ] 5/8 · #278 — Front-end injection hardening
- [ ] **6/8 · #279 — Handsontable cleanup ← this PR**
- [ ] 7/8 · #280 — CI/CD & deployment
- [ ] 8/8 · #281 — Documentation

Related but independent (off `master`): #282 — GitHub Source link.

---

**Part 6 of 8** splitting #273. **Stacked on #278** (base = `security/05-headers`).

## What this PR does
Small cleanup around the editable grids. The app uses the MIT-licensed Handsontable **6.2.2** bundled with `rhandsontable` (an earlier 10.0.0 override was reverted for licensing reasons; that revert is already reflected in `master`'s `createHOT.R`, so it is not part of this diff).

- Namespace-qualify the modal-grid constructors as `rhandsontable::rhandsontable()` in `app_server.R`.
- Document in `shiny-utils.R` that the client-side `hookSanitize` / `hookFilterKeys` hooks (`addHotHooks`) plus the server-side validators are the defense-in-depth layer over the 6.2.2 grid.

## Testing
`devtools::load_all()` clean; suite unchanged (109 passed).
