### PR TITLE
7/8 CI/CD & deployment hardening

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,4 +23,7 @@
 ^GEMINI\.md$
 ^AGENTS\.md$
 ^\.agents$
+^shiny_bookmarks$
+^\.Renviron$
+^\.Renviron\..*$
 

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -9,6 +9,9 @@ on:
 
 name: R-CMD-check
 
+permissions:
+  contents: read
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -25,27 +28,28 @@ jobs:
           - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       RENV_CONFIG_AUTOLOADER_ENABLED: FALSE
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           upload-snapshots: false
           upload-results: false

--- a/.github/workflows/shiny-deploy-production.yaml
+++ b/.github/workflows/shiny-deploy-production.yaml
@@ -1,11 +1,14 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # see https://www.tidyverse.org/blog/2022/06/actions-2-0-0/ for info on setup-r-dependencies@v2
+# Legacy shinyapps.io deployment retained for manual rollback during the
+# Connect Cloud migration. Connect Cloud publishes directly from GitHub.
 on:
-  push:
-    branches: [main, master]
   workflow_dispatch:
 
-name: Deployment Production
+name: Legacy shinyapps.io Production (manual only)
+
+permissions:
+  contents: read
 
 jobs:
   deployment-production:
@@ -13,30 +16,30 @@ jobs:
     environment:
       name: production
       url: https://stanpumpr.io
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: 'renv'
           use-public-rspm: true
 
       - name: Install system dependencies
-        # renv restores the full lockfile (incl. dev deps like gert -> libgit2,
-        # rJava -> JDK, systemfonts/ragg -> cairo/freetype). Install the system
+        # renv restores the full lockfile (incl. dev deps like gert -> libgit2
+        # and systemfonts/ragg -> cairo/freetype). Install the system
         # libraries these load against so the restore doesn't fail when a package
         # has no prebuilt binary. Mirrors the R-CMD-check workflow's system deps.
-        run: sudo apt-get update && sudo apt-get install -y cmake default-jdk libcairo2-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libpng-dev libx11-dev
+        run: sudo apt-get update && sudo apt-get install -y cmake libcairo2-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libpng-dev libx11-dev
 
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: r-lib/actions/setup-renv@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install stanpumpR from GitHub
         run: |
-          pkg_ref <- "${{ github.repository }}"
+          pkg_ref <- paste0("${{ github.repository }}@", "${{ github.sha }}")
           remotes::install_github(pkg_ref, upgrade = "never", force = TRUE)
           find.package("stanpumpR") # force a failure if package didn't install so GHA won't continue
         shell: Rscript {0}
@@ -50,8 +53,14 @@ jobs:
         run: |
           shinyConfig <- list(
             default = list(
-              email_username = "${{ secrets.SHINY_CONFIG_EMAIL_USERNAME }}",
-              email_password = "${{ secrets.SHINY_CONFIG_EMAIL_PASSWORD }}",
+              email_enabled = FALSE,
+              # shinyapps.io does not support disk-backed ("server") bookmarks;
+              # URL bookmarking is required there. The URL carries no PHI
+              # (recipient/comments/exact age excluded; age >= 90 normalized) and
+              # restored state is re-validated server-side. Use "server" only on
+              # a host with state storage (e.g. Posit Connect Cloud).
+              bookmark_mode = "url",
+              allow_url_debug = FALSE,
               debug = 0
             )
           )

--- a/.github/workflows/shiny-pr-1-triage.yaml
+++ b/.github/workflows/shiny-pr-1-triage.yaml
@@ -2,7 +2,7 @@
 # this repo, or if it came from a fork then add a comment telling maintainers
 # that they need to add this label manually to trigger a deployment. This is
 # done for security reasons, so that other people can't trigger PRs that steal
-# GitHub secrets (they would be able to access the shinyapps.io and gmail accounts)
+# GitHub secrets (they would be able to access the preview deployment account)
 
 name: Shiny PR 1 Triage
 
@@ -19,9 +19,8 @@ jobs:
     steps:
       - name: Label internal PR
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ secrets.MY_PAT }}
           script: |
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -31,12 +30,12 @@ jobs:
             });
       - name: Comment on fork PR
         if: github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: "**Fork detected**\n\nFor security reasons, a maintainer must add the `DEPLOY` label to deploy this PR.\n\n*Remember that any future commits added to the PR will re-deploy the app, so only do this if you trust the author.*"
+              body: "**Fork detected**\n\nFor security reasons, a maintainer must review the exact head commit and add the `DEPLOY` label to deploy this PR. New commits require a fresh review and reapplication of the label."
             });

--- a/.github/workflows/shiny-pr-2-deploy.yaml
+++ b/.github/workflows/shiny-pr-2-deploy.yaml
@@ -4,6 +4,10 @@
 # Workflow borrows from https://github.com/r-lib/actions/tree/v2/examples
 name: Shiny PR 2 Deploy
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types: [labeled, synchronize]
@@ -30,34 +34,36 @@ jobs:
     environment:
       name: pr-preview
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      SHINY_APP_NAME: ${{ vars.SHINY_APP_NAME }}_PR_${{ github.event.pull_request.number }}
+      # Preview credentials must belong to an isolated account that cannot read,
+      # modify, or deploy production applications.
+      SHINY_APP_NAME: ${{ vars.PR_SHINY_APP_NAME }}_PR_${{ github.event.pull_request.number }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           # This job only runs for fork PRs that a maintainer has explicitly
           # labeled DEPLOY (see the `if:` above), not arbitrary forks
           allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: 'renv'
           use-public-rspm: true
 
       - name: Install system dependencies
-        # renv restores the full lockfile (incl. dev deps like gert -> libgit2,
-        # rJava -> JDK, systemfonts/ragg -> cairo/freetype). Install the system
+        # renv restores the full lockfile (incl. dev deps like gert -> libgit2
+        # and systemfonts/ragg -> cairo/freetype). Install the system
         # libraries these load against so the restore doesn't fail when a package
         # has no prebuilt binary. Mirrors the R-CMD-check workflow's system deps.
-        run: sudo apt-get update && sudo apt-get install -y cmake default-jdk libcairo2-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libpng-dev libx11-dev
+        run: sudo apt-get update && sudo apt-get install -y cmake libcairo2-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgit2-dev libpng-dev libx11-dev
 
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: r-lib/actions/setup-renv@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install stanpumpR from GitHub
         run: |
@@ -79,26 +85,25 @@ jobs:
             default = list(
               title = paste("PR #${{ github.event.pull_request.number }}:", Sys.getenv("PR_TITLE")),
               long_title = TRUE,
-              email_username = "${{ secrets.SHINY_CONFIG_EMAIL_USERNAME }}",
-              email_password = "${{ secrets.SHINY_CONFIG_EMAIL_PASSWORD }}",
+              email_enabled = FALSE,
               debug = 1
             )
           )
           yaml::write_yaml(shinyConfig, "config.yml", fileEncoding = "UTF-8")
-          rsconnect::setAccountInfo("${{ vars.SHINY_ACCOUNT }}", "${{ secrets.SHINY_TOKEN }}", "${{ secrets.SHINY_SECRET }}")
+          rsconnect::setAccountInfo("${{ vars.PR_SHINY_ACCOUNT }}", "${{ secrets.PR_SHINY_TOKEN }}", "${{ secrets.PR_SHINY_SECRET }}")
           rsconnect::deployApp(
-            appName = "${{ env.SHINY_APP_NAME }}", account = "${{ vars.SHINY_ACCOUNT }}",
+            appName = "${{ env.SHINY_APP_NAME }}", account = "${{ vars.PR_SHINY_ACCOUNT }}",
             appDir = ".", appFiles = c("app.R", "config.yml"), forceUpdate = TRUE
           )
         shell: Rscript {0}
 
       - name: Comment PR with deployment URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `**Preview Deployment**\n\nThis PR has been deployed to: https://${{ vars.SHINY_ACCOUNT }}.shinyapps.io/${{ env.SHINY_APP_NAME }}/\n\n_This deployment will be automatically cleaned up when the PR is closed._`
+              body: `**Preview Deployment**\n\nThis PR has been deployed to: https://${{ vars.PR_SHINY_ACCOUNT }}.shinyapps.io/${{ env.SHINY_APP_NAME }}/\n\n_This deployment will be automatically cleaned up when the PR is closed._`
             })

--- a/.github/workflows/shiny-pr-3-cleanup.yaml
+++ b/.github/workflows/shiny-pr-3-cleanup.yaml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           use-public-rspm: true
 
@@ -22,16 +22,16 @@ jobs:
 
       - name: Delete app
         env:
-          SHINY_APP_NAME: ${{ vars.SHINY_APP_NAME }}_PR_${{ github.event.pull_request.number }}
+          SHINY_APP_NAME: ${{ vars.PR_SHINY_APP_NAME }}_PR_${{ github.event.pull_request.number }}
         run: |
           install.packages("rsconnect")
-          rsconnect::setAccountInfo("${{ vars.SHINY_ACCOUNT }}", "${{ secrets.SHINY_TOKEN }}", "${{ secrets.SHINY_SECRET }}")
-          rsconnect::terminateApp(appName = "${{ env.SHINY_APP_NAME }}", account = "${{ vars.SHINY_ACCOUNT }}")
-          rsconnect::purgeApp(appName = "${{ env.SHINY_APP_NAME }}", account = "${{ vars.SHINY_ACCOUNT }}")
+          rsconnect::setAccountInfo("${{ vars.PR_SHINY_ACCOUNT }}", "${{ secrets.PR_SHINY_TOKEN }}", "${{ secrets.PR_SHINY_SECRET }}")
+          rsconnect::terminateApp(appName = "${{ env.SHINY_APP_NAME }}", account = "${{ vars.PR_SHINY_ACCOUNT }}")
+          rsconnect::purgeApp(appName = "${{ env.SHINY_APP_NAME }}", account = "${{ vars.PR_SHINY_ACCOUNT }}")
         shell: Rscript {0}
       - name: Remove DEPLOY label
         if: always()   # even if previous step fails
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             try {

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 
 config.yml
+shiny_bookmarks/
 /ignore
 /Slides
 /rsconnect
@@ -15,6 +16,9 @@ config.yml
 
 # User-specific files
 .Ruserdata
+.Renviron
+.Renviron.*
+!.Renviron.example
 
 # Default R plot output
 Rplots.pdf

--- a/.rscignore
+++ b/.rscignore
@@ -10,3 +10,6 @@ stanpumpR_0.0.0.1.tar.gz
 tests
 vignettes
 Original Stanpump
+shiny_bookmarks
+.Renviron
+.Renviron.*

--- a/tools/write-connect-manifest.R
+++ b/tools/write-connect-manifest.R
@@ -1,0 +1,27 @@
+# Generate the dependency manifest required by Posit Connect Cloud.
+# Run from the repository root after restoring the project dependencies.
+if (!requireNamespace("rsconnect", quietly = TRUE)) {
+  stop("Install the rsconnect package before generating manifest.json.")
+}
+
+rsconnect::writeManifest(
+  appDir = ".",
+  appPrimaryDoc = "app.R"
+)
+
+manifest <- jsonlite::fromJSON("manifest.json", simplifyVector = FALSE)
+stanpumpMetadata <- manifest$packages$stanpumpR
+if (is.null(stanpumpMetadata)) {
+  stop("manifest.json does not include stanpumpR as an application dependency.")
+}
+remoteType <- stanpumpMetadata$RemoteType
+if (is.null(remoteType)) remoteType <- stanpumpMetadata$Source
+if (is.null(remoteType)) remoteType <- ""
+if (!tolower(remoteType) %in% c("github", "git")) {
+  stop(
+    "stanpumpR is not recorded as a GitHub dependency. Install the exact GitHub ",
+    "revision, regenerate the manifest, and inspect its stanpumpR entry."
+  )
+}
+
+message("Wrote manifest.json. Verify its stanpumpR commit, then commit the manifest.")


### PR DESCRIPTION
### 🧩 #273 split — 8 stacked PRs (review & merge in order)

- [ ] 1/8 · #274 — Server-side input validation
- [ ] 2/8 · #275 — Age/PHI normalization
- [ ] 3/8 · #276 — Bookmarking privacy
- [ ] 4/8 · #277 — Email/SMTP hardening
- [ ] 5/8 · #278 — Front-end injection hardening
- [ ] 6/8 · #279 — Handsontable cleanup
- [ ] **7/8 · #280 — CI/CD & deployment ← this PR**
- [ ] 8/8 · #281 — Documentation

Related but independent (off `master`): #282 — GitHub Source link.

---

**Part 7 of 8** splitting #273. **Stacked on #279** (base = `security/06-handsontable`).

## What this PR does
- Pin GitHub Actions to commit SHAs; pin the production install to the triggering commit; isolate fork-PR previews to `PR_SHINY_*` credentials (`.github/workflows/`).
- Exclude secrets, `config.yml`, and generated bookmark directories from Git, package builds, and deploy bundles (`.gitignore`, `.Rbuildignore`, `.rscignore`).
- Add `tools/write-connect-manifest.R` to generate the `manifest.json` Posit Connect Cloud requires, recording the exact GitHub revision.

## Notes
- The deployment/Connect-Cloud prose docs land in the final docs PR (#8).
- CI-config only; no package code changes.
