### PR TITLE
8/8 Documentation: architecture, security/privacy/deployment, agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ renv::restore()           # Restore pinned R package dependencies from renv.lock
    - `advanceClosedFormPO_IM_IN.R` (extravascular 1st-order absorption)
 5. **Plot & Render**: `simulationPlot.R` generates `ggplot2` output, results table, and dosing suggestions (`suggest.R`).
 
-*Note: `recalculatePK()` and `processdoseTable()` perform smart diffing, re-simulating only drugs whose inputs have changed.*
+*Note: `drugs()` rebuilds its per-drug list from `NULL` on every run, so `recalculatePK()` and `processdoseTable()` fully recompute every drug (PK + simulation) on any input change. `processdoseTable()` has a per-drug diff meant to skip unchanged drugs, but it is currently inert (`recalculatePK()` clears each drug's `$DT` right before it runs). What keeps the app fast is the closed-form solution, not incremental skipping.*
 
 ---
 
@@ -64,3 +64,19 @@ renv::restore()           # Restore pinned R package dependencies from renv.lock
 - Created `GEMINI.md` and `AGENTS.md` to establish cross-machine context and workflow guidelines for Antigravity.
 - Verified workspace setup and reviewed core architecture (`docs/architecture.md`, `CLAUDE.md`, `DESCRIPTION`).
 - Updated `.Rbuildignore` to ignore agent markdown files during `R CMD check`.
+- Created `codex/security-hardening` from `master` after a clinical-environment security review.
+- Added server-side input and bookmark validation, secure server bookmarks, production debug restrictions, and bounded simulation inputs.
+- Disabled email by default, added recipient-domain and SMTP configuration, and moved exports into private per-send temporary directories with guaranteed cleanup.
+- Overrode rhandsontable's vulnerable Handsontable 6.2.2 assets with 10.0.0 and documented its separate hospital/commercial licensing requirement.
+- Pinned GitHub Actions, pinned production deployment to the triggering commit, and isolated preview deployment credentials from production.
+- Security hardening committed on `codex/security-hardening` as `93f902a` (`Harden clinical deployment security`); 102 tests pass and all workflow YAML files parse.
+- Extended email privacy hardening: visibly normalized ages 90+ to 89 before simulation/export/bookmarking, removed recipient-domain restrictions without persisting or logging recipient addresses, added a PHI warning to comments, kept the disabled email panel visible for configuration/testing, and labeled UI/email exports as simulations rather than patient records.
+- SMTP username and app password are read only from `STANPUMPR_EMAIL_USERNAME` and `STANPUMPR_EMAIL_PASSWORD`; plaintext credentials in `config.yml` are no longer supported.
+- Connect Cloud migration preparation: runtime configuration works without an untracked `config.yml`, production email settings can come entirely from managed variables, Java-based `mailR` was replaced with curl SMTP, the legacy shinyapps.io production workflow is manual-only, and `tools/write-connect-manifest.R` generates the required committed manifest.
+- Consolidated documentation in `docs/security-hardening-changelog.md`, `docs/privacy-and-phi.md`, `docs/security-deployment.md`, and `docs/connect-cloud-deployment.md`, including implemented controls, verification status, operational requirements, and residual risks.
+
+### 2026-08-12
+- Changed the default `bookmark_mode` from `server` to `url` in `R/globalVariables.R` and in the shinyapps.io production deploy workflow (`.github/workflows/shiny-deploy-production.yaml`), fixing "server is not configured for saving sessions to disk" on hosts without disk-backed bookmark storage (shinyapps.io). Rationale: the URL carries no confidential data (recipient/comments/exact age are in `bookmarksToExclude`; ages 90+ are normalized to 89 before persistence).
+- Re-verified URL injection is blocked against Shiny 1.14.0: URL bookmark state is decoded by `shiny:::RestoreContext$decodeStateQueryString` via `safeFromJSON` (jsonlite) with no `unserialize`/`eval`/`readRDS` on URL content (`readRDS` is only in the `server`/`_state_id_` path, keyed by an alphanumeric-validated id). The sole R code sink, `eval(call(drug, ...))` in `getDrugPK.R`, is gated on every path by `validateDoseTableInput()` (in both `onRestored` and `doseTableClean()`), which rejects drugs outside `drugDefaults$Drug`. `sex` is enum-validated; age/weight/height are range-validated; free-text (recipient/comments) is bookmark-excluded and `hover_info` HTML is `htmlEscape`d.
+- Updated `config.yml.sample` and docs (`security-deployment.md`, `privacy-and-phi.md`, `connect-cloud-deployment.md`, `security-hardening-changelog.md`, `architecture.md`, `architecture.html`) to reflect URL as the default and `server` as a Connect Cloud option.
+- Reverted the Handsontable 10.0.0 override (see 2026-08-11 entry) back to the MIT-licensed 6.2.2 bundled with `rhandsontable`, for licensing reasons (Handsontable 7.0+ requires a commercial license unsuitable for the hospital/free deployment). Removed `secureRHandsontable()` and `handsontablePatchedDependency()` from `R/shiny-utils.R` (call sites in `createHOT.R` and `app_server.R` now call `rhandsontable::rhandsontable()` directly), the `app_ui()` head dependency injection, the vendored `inst/www/handsontable-10.0.0/` assets, the `handsontable_license_key` config + its `app_run.R` validation + `config.yml.sample` line, and the now-inverted `tests/testthat/test-shiny-utils.R`. **Kept** the version-independent defense-in-depth: the `hookSanitize` / `hookFilterKeys` grid hooks (`addHotHooks()` + `inst/www/hot_funs.js`) and all server-side validators. Trade-off: reintroduces 6.2.2's client-side XSS exposure (< 8.2.0; CVE-2021-23446), mitigated but not eliminated by those hooks and validators.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,27 @@ Orientation for Claude Code working in this repo. Human-facing docs live in
 [`docs/architecture.html`](docs/architecture.html) (visual map) and
 [`docs/architecture.md`](docs/architecture.md).
 
+## Security/privacy audit handoff
+
+The active work is on `codex/security-hardening`. Review the working tree, not only commit
+`93f902a`; later email, PHI, and Connect Cloud changes are currently uncommitted.
+
+Read these first, then verify them independently:
+
+- `docs/security-hardening-changelog.md` — change and verification inventory.
+- `docs/privacy-and-phi.md` — data-flow assessment and residual PHI paths.
+- `docs/security-deployment.md` — secure defaults and external controls.
+- `docs/connect-cloud-deployment.md` — manifest, variables, and acceptance procedure.
+- `AGENTS.md` — chronological work log and repository rules.
+
+Audit server-side input validation; bookmark exclusions and restoration; age normalization;
+free-text and recipient PHI risks; SMTP TLS/MIME/header injection; temporary-file cleanup; secret,
+log, and deployment exclusions; dependency consistency; pinned workflows; and startup without
+`config.yml`. Confirm that the Connect Cloud manifest records the exact GitHub revision.
+
+Known incomplete verification: the updated full `devtools::test()` suite and live Connect Cloud
+acceptance test have not yet been completed, and `manifest.json` has not yet been generated.
+
 ## What this is
 
 stanpumpR is a Shiny web app that simulates plasma and effect-site concentrations of
@@ -18,11 +39,12 @@ re-render fast.
 
 ```r
 devtools::load_all(".")
-run_app()          # add ?debug=1 to the URL for the live log + profiler
+run_app()          # URL debug is disabled unless explicitly allowed in local configuration
 devtools::test()   # testthat suite
 ```
 
-Requires a `config.yml` (copy from `config.yml.sample`). Package versions are pinned with
+`config.yml` is optional; secure built-in defaults apply when absent. SMTP credentials are read
+only from `STANPUMPR_EMAIL_*` environment variables. Package versions are pinned with
 **renv** — after pulling `renv.lock` changes run `renv::restore()`.
 
 Developed and deployed on **R 4.6.1** with current CRAN package versions (all CRAN, no GitHub
@@ -37,13 +59,24 @@ One dependency chain; Shiny re-runs only what an edit invalidates:
 inputs (covariates, doseTableHTML, events, graph opts)
   → doseTableClean() / eventTableClean() / testCovariates()   # clean + validate
   → drugs()            # A: recalculatePK() → getDrugPK() per drug (covariates → coefficients)
-                       # B: processdoseTable() → simCpCe() per changed drug (simulate)
+                       # B: processdoseTable() → simCpCe() per drug (simulate)
   → simulationPlotRetval() = simulationPlot(...)   # build ggplot + result tables
   → output$PlotSimulation, output$hover_info, Suggest Dosing, email slide
 ```
 
-`recalculatePK()` and `processdoseTable()` both mutate a persistent per-drug list and **skip
-unchanged drugs** — preserve that diffing behavior when editing them.
+`recalculatePK()` and `processdoseTable()` build up a per-drug list (each returns the modified
+list) that `drugs()` feeds from one into the next. Note: `drugs()` is a plain `reactive()` that
+starts each run with `newDrugs <- NULL`, so the list is **rebuilt from scratch on every
+invalidation** — it is not cached across renders.
+
+`processdoseTable()` contains a diff (`!identical(tempDT, drugs[[drug]]$DT) | …`) meant to skip a
+drug whose dose/event subset is unchanged, and its header comment still claims it does. That skip
+is currently **inert**: `drugs()` starts from `NULL` and `recalculatePK()` sets each drug's `$DT`
+to `NULL` immediately before `processdoseTable()` runs, so the stored `$DT` is always `NULL` and
+the diff is always TRUE. `recalculatePK()` has no skip logic of its own. Net effect: **every drug
+is fully recomputed (PK + simulation) on every change to any input.** Reviving the skip would
+require persisting the previous `drugs()` value across renders (e.g. via `isolate()`) and stopping
+`recalculatePK()` from clearing `$DT` — a behavioral change; don't assume the diff works today.
 
 ## The PK/PD engine (`R/`)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -39,7 +39,7 @@ renv::restore()           # Restore pinned R package dependencies from renv.lock
    - `advanceClosedFormPO_IM_IN.R` (extravascular 1st-order absorption)
 5. **Plot & Render**: `simulationPlot.R` generates `ggplot2` output, results table, and dosing suggestions (`suggest.R`).
 
-*Note: `recalculatePK()` and `processdoseTable()` perform smart diffing, re-simulating only drugs whose inputs have changed.*
+*Note: `drugs()` rebuilds its per-drug list from `NULL` on every run, so `recalculatePK()` and `processdoseTable()` fully recompute every drug (PK + simulation) on any input change. `processdoseTable()` has a per-drug diff meant to skip unchanged drugs, but it is currently inert (`recalculatePK()` clears each drug's `$DT` right before it runs). What keeps the app fast is the closed-form solution, not incremental skipping.*
 
 ---
 

--- a/R/globalVariables.R
+++ b/R/globalVariables.R
@@ -67,6 +67,9 @@ DEBUG_LEVEL_VERBOSE <- 2
 
 DEFAULT_CONFIG <- list(
   title = "stanpumpR",
+  # "Examples and Help" nav link. Points to the separately deployed help app on
+  # shinyapps.io, whose source is maintained in its own repository:
+  # https://github.com/StevenLShafer/stanpumpR_HelpPage
   help_link = "https://steveshafer.shinyapps.io/stanpumpR_HelpPage",
   debug = DEBUG_LEVEL_OFF,
   allow_url_debug = FALSE,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ It is hoped that stanpumpR will encourage device manufacturers to develop the ne
 
 stanpumpR is a collaborative research project. Individuals interested in adding drugs, pharmacokinetic data sets, or new algorithms to stanpumpR are encourage to contact Dr. Shafer. It is hoped that eventually each drug in the stanpumpR library will be maintained by an investigator, who will assume responsibility for keeping the pharmacokinetics as up-to-date as possible.
 
+Security, privacy, and deployment documentation:
+
+- [Security deployment baseline](docs/security-deployment.md)
+- [Privacy and PHI assessment](docs/privacy-and-phi.md)
+- [Security hardening implementation record](docs/security-hardening-changelog.md)
+- [Posit Connect Cloud deployment](docs/connect-cloud-deployment.md)
+
 Near-term future developments in stanpumpR will include
 
 1. Oral opioids. StanpumpR is programmed for PO, IM, and IN delivery. Need to get good PK for the opioids. Note that only first order absorption pk is currently supported.
@@ -39,7 +46,7 @@ Requires R 4.6.x (developed and deployed on 4.6.1). CI exercises the current rel
     devtools::load_all(".")
     run_app()
     ```
-6. Debug mode shows a detailed log and a performance profiler. By default, debug mode is off in production. You can turn it on by adding `&debug=1` to the URL.
+6. Debug mode shows a detailed log and a performance profiler. It is off in production, and URL activation is disabled unless an administrator explicitly sets `allow_url_debug: true`.
 
 #### Running tests
 

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -16,5 +16,7 @@ default:
   email_smtp_ssl: true
   # Credentials and optional SMTP overrides use STANPUMPR_EMAIL_* environment
   # variables. Never put credentials in this file.
+  # "Examples and Help" nav link -> separately deployed help app on shinyapps.io.
+  # Source maintained in its own repo: github.com/StevenLShafer/stanpumpR_HelpPage
   help_link: "https://steveshafer.shinyapps.io/stanpumpR_HelpPage"
   debug: 0   # 0 = off, 1 = normal, 2 = verbose

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -329,8 +329,8 @@
         <p>
           <span class="fn">recalculatePK()</span> walks the drugs named in the dose table and,
           per drug, calls <span class="fn">getDrugPK()</span> to turn the patient's covariates
-          into a full set of rate constants, eigenvalues, and closed-form coefficients. Results
-          are cached on a per-drug list and only recomputed when covariates change.
+          into a full set of rate constants, eigenvalues, and closed-form coefficients. It does
+          this for every drug in the table on each run &mdash; there is no skip-if-unchanged logic.
         </p>
         <div class="reactives">
           <span class="chip r">drugs()  ·  step A</span>
@@ -346,10 +346,11 @@
           <div class="stage-files"><span class="file">processdoseTable.R</span><span class="file">simCpCe.R</span></div>
         </div>
         <p>
-          <span class="fn">processdoseTable()</span> diffs each drug's doses against the cached
-          result and re-simulates only what changed — calling <span class="fn">simCpCe()</span>,
-          which converts dose units, classifies bolus / infusion / oral routes, and dispatches to
-          the right closed-form solver. Output is a tidy time × site table per drug.
+          <span class="fn">processdoseTable()</span> simulates each drug in the table by calling
+          <span class="fn">simCpCe()</span>, which converts dose units, classifies bolus / infusion
+          / oral routes, and dispatches to the right closed-form solver. Output is a tidy time
+          &times; site table per drug. It carries a per-drug diff intended to skip unchanged drugs,
+          but that diff is currently inert (see the note below), so every drug is re-simulated.
         </p>
         <div class="reactives">
           <span class="chip r">drugs()  ·  step B</span>
@@ -391,7 +392,7 @@
         <div class="reactives">
           <span class="chip">output$PlotSimulation</span>
           <span class="chip">output$hover_info</span>
-          <span class="chip">URL bookmarking</span>
+          <span class="chip">Opaque saved-state links</span>
         </div>
       </div>
 
@@ -400,10 +401,14 @@
     <div class="note">
       <span class="mk">WHY IT'S FAST</span>
       <p>
-        Both <span class="fn">recalculatePK()</span> and <span class="fn">processdoseTable()</span>
-        mutate a persistent per-drug list and skip any drug whose inputs are unchanged. Combined
-        with closed-form solutions (no ODE integration), a dose edit re-simulates just the one drug
-        it touched.
+        <span class="fn">recalculatePK()</span> and <span class="fn">processdoseTable()</span> build
+        a per-drug list that <span class="fn">drugs()</span> threads through, but that list is not
+        cached across renders: <span class="fn">drugs()</span> is a plain reactive that restarts
+        from <code>NULL</code> each run, so every drug is fully recomputed on any input change.
+        What keeps it fast is the closed-form solution (no ODE integration), not incremental
+        skipping &mdash; <span class="fn">processdoseTable()</span>'s per-drug diff exists but is
+        currently inert (<span class="fn">recalculatePK()</span> clears each drug's <code>$DT</code>
+        just before it runs).
       </p>
     </div>
   </div>
@@ -561,7 +566,7 @@
         <div class="layer-head"><span class="tag">Shell</span><h3>App bootstrap &amp; framework</h3><span class="role">entry + wiring</span></div>
         <div class="layer-body">
           <div class="frow"><span class="fname">app.R</span><span class="fdesc">One line: <code>stanpumpR::run_app()</code> — the deploy entry point.</span></div>
-          <div class="frow"><span class="fname">app_run.R</span><span class="fdesc">Loads libraries, merges <code>config.yml</code> with defaults, sets the ggplot theme, mounts assets, launches <code>shinyApp()</code> with URL bookmarking.</span></div>
+          <div class="frow"><span class="fname">app_run.R</span><span class="fdesc">Loads libraries, merges <code>config.yml</code> with defaults, sets the ggplot theme, mounts assets, and launches <code>shinyApp()</code> with configurable secure bookmarking.</span></div>
           <div class="frow"><span class="fname">app_ui.R</span><span class="fdesc">The entire bslib UI — navbar, sidebar accordions, dose/event grids, plot card, debug panel.</span></div>
           <div class="frow"><span class="fname">app_server.R</span><span class="fdesc">The 46 KB reactive heart — every reactive, observer, output, and modal.</span></div>
           <div class="frow"><span class="fname">app_globals.R</span><span class="fdesc">Initial tables, bookmark exclusion list, and the <span class="fn">outputComments()</span> logger.</span></div>
@@ -601,7 +606,7 @@
           <div class="frow"><span class="fname">simulationPlot.R</span><span class="fdesc">Assembles the composite <code>ggplot2</code> figure and its data tables.</span></div>
           <div class="frow"><span class="fname">setLinetypes.R</span><span class="fdesc">Maps normalization + user choices to plasma/effect linetypes.</span></div>
           <div class="frow"><span class="fname">suggest.R</span><span class="fdesc">"Suggest Dosing" — optimizes a regimen to hit a target effect-site concentration.</span></div>
-          <div class="frow"><span class="fname">sendSlide.R</span><span class="fdesc">Renders an <code>officer</code> PowerPoint slide from <code>Template.pptx</code> and emails it via <code>mailR</code>.</span></div>
+          <div class="frow"><span class="fname">sendSlide.R</span><span class="fdesc">Renders an <code>officer</code> PowerPoint slide from <code>Template.pptx</code> and emails it via curl SMTP with mandatory TLS.</span></div>
         </div>
       </div>
 
@@ -644,14 +649,14 @@
       </div>
       <div class="card">
         <span class="k">state</span>
-        <h3>URL bookmarking</h3>
-        <p>Shiny <code>enableBookmarking="url"</code> encodes inputs into a shareable link; <code>bookmarksToExclude</code> keeps transient UI state out.</p>
+        <h3>Saved simulations</h3>
+        <p>URL bookmarking is the default so saved state is a shareable link that works on hosts without server-side storage; opaque server-stored IDs are available where the host supports them (e.g. Posit Connect Cloud). The URL carries no confidential data &mdash; <code>bookmarksToExclude</code> drops recipient/comments/exact age and transient UI state, ages 90+ are normalized, and restored state is decoded as JSON and re-validated server-side.</p>
         <div class="files"><span class="file">app_globals.R</span></div>
       </div>
       <div class="card">
         <span class="k">observability</span>
         <h3>Debug &amp; profiler</h3>
-        <p><code>&amp;debug=1</code> reveals a live log (<span class="fn">outputComments</span>) and a per-reactive profiler (<span class="fn">profileCode</span>).</p>
+        <p>The live log (<span class="fn">outputComments</span>) and per-reactive profiler (<span class="fn">profileCode</span>) are disabled in production. URL activation requires the explicit <code>allow_url_debug</code> configuration flag.</p>
         <div class="files"><span class="file">app_globals.R</span><span class="file">app_server.R</span></div>
       </div>
       <div class="card">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,16 +29,20 @@ flowchart TD
     A["<b>01 Inputs</b> — app_ui.R<br/>covariates · dose grid · events · graph options · plot clicks"]
     B["<b>02 Normalize & validate</b> — server-helpers.R<br/>doseTableClean() · eventTableClean() · testCovariates()"]
     C["<b>03 Resolve PK</b> — getDrugPK.R<br/>recalculatePK(): covariates → coefficients, per drug"]
-    D["<b>04 Simulate</b> — simCpCe.R<br/>processdoseTable(): re-simulate only changed drugs"]
+    D["<b>04 Simulate</b> — simCpCe.R<br/>processdoseTable(): simulate each drug in the table"]
     E["<b>05 Assemble plot</b> — simulationPlot.R<br/>build ggplot + allResults / plotResults"]
     F["<b>06 Render & interact</b> — app_server.R<br/>PlotSimulation · hover · click-to-dose · Suggest · email"]
     A --> B --> C --> D --> E --> F
     C -. "drugs() reactive" .- D
 ```
 
-Both `recalculatePK()` and `processdoseTable()` mutate a persistent per-drug list and **skip
-any drug whose inputs are unchanged**. Combined with closed-form solutions (no integration), a
-single dose edit re-simulates just the one drug it touched.
+`recalculatePK()` and `processdoseTable()` build up a per-drug list that `drugs()` threads from
+one into the next. `drugs()` is a plain `reactive()` that starts each run with `newDrugs <- NULL`,
+so the list is rebuilt from scratch on every invalidation — it is **not** cached across renders,
+and every drug is fully recomputed (PK + simulation) on any input change. `processdoseTable()` does
+contain a per-drug diff, but it is currently inert (`recalculatePK()` clears each drug's `$DT`
+right before it runs, so the diff always fires). What keeps this fast is the closed-form solution
+(no numeric integration), not incremental skipping.
 
 ### Key reactives (in `app_server.R`)
 
@@ -113,7 +117,7 @@ Gaussian absorption model; not exported or wired into the engine (see its proven
 
 **Output — plot, dosing advisor & export**
 `simulationPlot.R`, `setLinetypes.R`, `suggest.R` (target-controlled dosing optimizer),
-`sendSlide.R` (renders an `officer` PPTX from `Template.pptx`, emails via `mailR`).
+`sendSlide.R` (renders an `officer` PPTX from `Template.pptx`, emails via curl SMTP).
 
 **Util — time & misc**
 `clockTimeToDelta.R`, `deltaToClockTime.R`, `hourMinute.R`, `utils.R`,
@@ -124,8 +128,8 @@ Gaussian absorption model; not exported or wired into the engine (see its proven
 - **Suggest Dosing** (`suggest.R`) — optimizes bolus + infusion to reach/hold a target concentration.
 - **Email a slide** (`sendSlide.R`) — branded PPTX of the current simulation plus a URL that reconstructs the state.
 - **Editors & modals** — in-app Drug Library and Drug Thresholds editors; click-to-add-dose / double-click-to-edit from plot coordinates.
-- **URL bookmarking** — `enableBookmarking = "url"`; `bookmarksToExclude` keeps transient UI state out of the link.
-- **Debug & profiler** — `?debug=1` reveals a live log (`outputComments`) and a per-reactive profiler (`profileCode`).
+- **Saved simulations** — URL bookmarking is the default so saved state is a shareable link that works on hosts without server-side storage (e.g. shinyapps.io); opaque server-side bookmarking is available where the host supports it (e.g. Posit Connect Cloud). The URL carries no confidential data (`bookmarksToExclude` drops recipient/comments/exact age and transient UI state; ages 90+ are normalized), and restored state is decoded as JSON and re-validated server-side.
+- **Debug & profiler** — the live log (`outputComments`) and per-reactive profiler (`profileCode`) are disabled in production. URL activation requires the explicit `allow_url_debug` configuration flag.
 - **Front-end assets** — `inst/www/`: `app.css`, `app.js`, `hot_funs.js` (Handsontable hooks, drug-default injection).
 - **Reproducibility** — `renv.lock` pins package versions; deps declared in `DESCRIPTION`.
 - **Tests / CI** — ~40 files in `tests/testthat/` (one per drug plus PK, plotting, helper suites); R-CMD-check via GitHub Actions.

--- a/docs/connect-cloud-deployment.md
+++ b/docs/connect-cloud-deployment.md
@@ -1,0 +1,60 @@
+# Posit Connect Cloud deployment
+
+Connect Cloud publishes this Shiny application directly from GitHub. It does not use
+`renv.lock` to build the deployed R library; a committed `manifest.json` is required.
+
+## Before connecting the repository
+
+1. Commit and push the application changes to the intended production branch.
+2. Install that exact public GitHub revision locally so the manifest records `stanpumpR` as a
+   GitHub dependency rather than an unavailable local package:
+
+   ```r
+   remotes::install_github("StevenLShafer/stanpumpR@<commit-sha>", upgrade = "never")
+   ```
+
+3. Run the complete test suite, then generate the Connect Cloud manifest from the repository root:
+
+   ```r
+   source("tools/write-connect-manifest.R")
+   ```
+
+4. Confirm that the `stanpumpR` entry in `manifest.json` identifies the expected GitHub commit.
+   Review and commit the manifest. Regenerate it whenever `DESCRIPTION`, `renv.lock`, or
+   an application dependency changes.
+5. In Connect Cloud, select `app.R` as the primary file and the production branch as the
+   publishing branch.
+
+The app starts with secure built-in defaults when the ignored local `config.yml` is absent.
+
+## Connect Cloud variables
+
+Configure these encrypted variables on the content item:
+
+- `STANPUMPR_EMAIL_USERNAME`: Gmail/Google Workspace sender address.
+- `STANPUMPR_EMAIL_PASSWORD`: Google app-specific password.
+- `STANPUMPR_EMAIL_ENABLED`: `true` to enable sending.
+
+Optional non-secret overrides are `STANPUMPR_EMAIL_SMTP_HOST`,
+`STANPUMPR_EMAIL_SMTP_PORT`, and `STANPUMPR_EMAIL_SMTP_SSL`. Gmail defaults are
+`smtp.gmail.com`, `587`, and `true`; port 587 uses mandatory STARTTLS.
+
+Never place variable values in GitHub, `config.yml`, `.Renviron`, `manifest.json`, or build logs.
+
+## Content settings
+
+- Use the production branch and enable automatic publish on push only after a successful manual
+  deployment.
+- Configure the custom domain in Connect Cloud; TLS certificates are managed by the platform.
+- Keep production debug disabled and URL debug activation disabled.
+- The app defaults to URL bookmarking, which works on every host. Connect Cloud also supports
+  disk-backed Shiny bookmarkable state, so you may optionally set `bookmark_mode: server` here to
+  keep saved state off the URL; if you do, verify bookmark retention and restore as part of the
+  production acceptance test. (Do not use `server` on shinyapps.io, which lacks state storage.)
+- Review content visibility and authentication before making the application public.
+
+## Acceptance test
+
+After each deployment, verify app startup, age normalization, dose/event validation, bookmark
+restore, export generation, email delivery, temporary-file cleanup, and absence of credentials
+or recipient addresses in application logs.

--- a/docs/privacy-and-phi.md
+++ b/docs/privacy-and-phi.md
@@ -1,0 +1,47 @@
+# Privacy and PHI assessment
+
+This is an engineering assessment, not a legal determination that a deployment is HIPAA compliant.
+
+## Structured simulation data
+
+stanpumpR does not request a patient name, medical-record number, date of birth, address,
+telephone number, encounter number, account number, or patient email address. It processes age,
+sex, height, weight, pregnancy/renal/pharmacogenomic selections, medication regimens, clinical
+events, and simulated concentrations. These are health-related data but are not direct identifiers
+by themselves. Ages entered as 90 or older are visibly changed to 89 before calculation, export,
+and bookmark persistence; the exact entered age is excluded from saved state.
+
+## Paths by which PHI can still enter
+
+- **Comments:** The optional email comment is free text. Its placeholder says not to enter PHI,
+  but a user can still type a name, MRN, date, or other identifier.
+- **Recipient:** The address is used transiently for SMTP and excluded from bookmarks and logs. If
+  it is a patient's address, the mail system links that identifier to the simulation and attachments.
+- **External correlation:** An unusual combination of demographics, regimen, procedure timing,
+  user identity, IP address, and outside knowledge could identify an individual.
+
+The strongest no-PHI boundary would require removing free-text comments and prohibiting delivery
+to patient addresses. The current design instead warns users, minimizes persistence, and assumes
+deployment and mail systems are operated with safeguards appropriate for possible PHI.
+
+## Storage and transmission
+
+- Bookmarks (URL by default, or opaque server-stored IDs where a host supports them) exclude
+  recipient, comments, exact age, and transient UI/debug fields; ages 90+ are normalized to 89
+  before persistence. Dose, event, and normalized simulation data remain in saved state. Because
+  the excluded and normalized fields never enter saved state, the URL contains no confidential
+  data. Restored URL state is decoded as JSON (no `unserialize`/`eval`) and re-validated
+  server-side.
+- Local bookmark directories are excluded from Git, package builds, and deployment bundles.
+- Email exports use a private temporary directory and are deleted on success or failure. The mail
+  provider may retain sent messages and attachments under its own policies.
+- Email uses authenticated SMTP with mandatory TLS when enabled. Transport failures do not expose
+  or log SMTP exception details.
+- PPTX, XLSX, PNG, UI, subject, and body identify the output as a simulation, not a patient record.
+
+## Operational requirements
+
+Connect Cloud visibility/authentication, bookmark retention, mail-provider agreements, audit-log
+access, incident response, and organizational policy remain deployment responsibilities. Never
+log simulation tables, bookmark tokens, recipient addresses, comments, credentials, or message
+contents in production.

--- a/docs/security-deployment.md
+++ b/docs/security-deployment.md
@@ -1,0 +1,86 @@
+# Security deployment baseline
+
+stanpumpR handles patient covariates and medication regimens. A clinical deployment must
+therefore treat all Shiny inputs and saved-state links as untrusted and potentially sensitive.
+
+## Secure defaults
+
+- `bookmark_mode: url` (the default) encodes saved-simulation state directly in a shareable
+  link and works on hosts without server-side state storage (e.g. shinyapps.io, which errors
+  with "server is not configured for saving sessions to disk" under `server`). The URL carries no
+  confidential data: recipient, comments, and exact age are excluded from bookmarks and ages
+  90+ are normalized to 89 before persistence. Restored URL state is decoded as JSON by Shiny
+  (no `unserialize`/`eval`) and re-validated by the server-side validators below, so a crafted
+  link cannot inject code or unknown drugs. Use `server` (opaque server-stored IDs) only on a
+  host that supports disk-backed bookmarks such as Posit Connect Cloud; use `disable` where
+  saved-state sharing is unnecessary.
+- `allow_url_debug: false` prevents users from enabling diagnostic output through the URL.
+- `email_enabled: false` disables sending while leaving the email panel visible with a deployment
+  status notice and PHI warning. If email is enabled, use an approved SMTP relay. Recipient
+  addresses are validated but are not restricted by domain, logged, or stored in bookmarks.
+- Server-side validators cap table sizes and reject unknown drugs, routes, events, non-finite
+  doses, overlong text, and forged plot dimensions.
+- Ages of 90 years or older are visibly normalized to 89 before simulation, export, or bookmark
+  persistence. Email comments warn users not to enter PHI. The email panel remains visible when
+  sending is disabled so that its privacy guidance and deployment status are apparent.
+
+## Required reverse-proxy controls
+
+The hosting or reverse-proxy layer must provide authentication, authorization, TLS, idle and
+absolute session expiry, request/body limits, websocket limits, and audit logging. It must also
+send these response headers; a HTML `<meta>` element is not sufficient for all directives:
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+X-Content-Type-Options: nosniff
+Referrer-Policy: no-referrer
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+```
+
+The inline-script exceptions remain necessary for the current Shiny/htmlwidgets stack. They
+make the strict server-side input validation security-critical.
+
+## Handsontable
+
+The editable grids use the Handsontable 6.2.2 build bundled with `rhandsontable` (the last
+MIT-licensed Handsontable release, so no commercial license key is required). Note that 6.2.2
+predates the fix for the client-side XSS issues in Handsontable < 8.2.0 (incl. CVE-2021-23446);
+the residual risk is mitigated — not eliminated — by the client-side sanitizing/key-filtering
+hooks (`hookSanitize` / `hookFilterKeys` in `inst/www/hot_funs.js`, applied via `addHotHooks()`)
+and the server-side validators, which reject any unknown drug/route/unit/event, non-finite value,
+overlong text, or oversized table on both the reactive path and bookmark restore. A deployment
+that needs a patched Handsontable must move to a licensed 8.2.0+/rhandsontable build.
+
+## Email
+
+Generated PPTX, XLSX, and PNG files are written to a private, unique temporary directory and
+deleted with `on.exit()` whether sending succeeds or fails. A hospital deployment should still
+prefer its approved internal mail relay and enforce identity-aware rate limiting outside Shiny.
+Recipient addresses are used transiently for delivery and are not included in bookmarks or
+application debug logs. Exported artifacts are labeled as simulations, not patient records.
+Generated local bookmark directories are excluded from Git, package builds, and deployment
+bundles. SMTP exception details are neither logged nor displayed to users because transport
+exceptions can include account or infrastructure information.
+Supply `STANPUMPR_EMAIL_USERNAME` and `STANPUMPR_EMAIL_PASSWORD` through the process environment
+or the hosting platform's secret manager. The application deliberately does not read these
+credentials from `config.yml`. For local development, put them in the user-level `~/.Renviron`
+rather than a project file. Do not commit them or print them in logs. If a credential has ever
+appeared in source control or a deployment bundle, revoke it before enabling email.
+
+Posit Connect Cloud supplies these values as encrypted content variables. Do not work around a
+hosting limitation by generating a plaintext `config.yml`, `.Renviron`, or other secret file in
+a deployment bundle.
+
+## Privacy boundary
+
+See `privacy-and-phi.md` for the field inventory, PHI entry paths, email implications, bookmark
+considerations, and the limits of what application code alone can claim about HIPAA compliance.
+
+## CI/CD
+
+GitHub Actions are pinned to immutable commits. Production installation is pinned to the
+workflow's triggering commit. Fork preview deployments use separate `PR_SHINY_*` credentials;
+those credentials must belong to an isolated preview account with no production access.
+
+See `security-hardening-changelog.md` for the complete implementation and verification record.

--- a/docs/security-hardening-changelog.md
+++ b/docs/security-hardening-changelog.md
@@ -1,0 +1,60 @@
+# Security hardening implementation record
+
+This record consolidates the work on `codex/security-hardening`. Operating requirements are in
+`security-deployment.md`; privacy boundaries are in `privacy-and-phi.md`; Connect Cloud procedures
+are in `connect-cloud-deployment.md`.
+
+## Implemented controls
+
+- Added server validation for covariates, dose/event/target tables, drugs, routes, units, finite
+  values, row counts, text lengths, simulation duration, plot dimensions, and restored bookmarks.
+- Defaulted to URL bookmarking (works on hosts without disk-backed state, e.g. shinyapps.io);
+  kept confidential data out of the URL (recipient/comments/exact age excluded, ages 90+
+  normalized) and re-validated restored state server-side. Shiny decodes URL state as JSON via
+  `safeFromJSON` (no `unserialize`/`eval`), and `validateDoseTableInput` gates the sole
+  `eval(call(drug,...))` sink, so a crafted link cannot inject code. `server` remains available
+  for hosts with state storage (Posit Connect Cloud). Restricted production/URL debugging.
+- Handsontable: the app uses the MIT-licensed 6.2.2 build bundled with `rhandsontable` (an earlier
+  10.0.0 override was reverted for licensing reasons — 7.0+ requires a commercial license). 6.2.2's
+  client-side XSS exposure (< 8.2.0; CVE-2021-23446) is mitigated by the `hookSanitize` /
+  `hookFilterKeys` grid hooks and the server-side validators, not by a version bump.
+- Added defense-in-depth CSP and documented required hosting-layer security headers.
+- Pinned GitHub Actions, pinned production installation, and isolated preview credentials.
+- Disabled email by default and retained a server-side send guard and per-session limit.
+- Validated recipient syntax/length and rejected header injection while allowing any valid domain.
+- Read SMTP credentials only from `STANPUMPR_EMAIL_*` environment variables.
+- Replaced Java-dependent `mailR`/`rJava` with curl SMTP, MIME attachments, and forced TLS.
+- Generated exports in private temporary directories with guaranteed cleanup; escaped HTML and
+  bookmark attributes; concealed transport errors; and avoided recipient logging.
+- Visibly normalized ages 90+ to 89 before calculation, export, and persistence.
+- Excluded recipient, comments, exact age, debug controls, and transient UI state from bookmarks.
+- Added the PHI warning and labeled the UI and exports as simulations, not patient records.
+- Excluded credentials, local configuration, and bookmark data from Git/build/deployment bundles.
+- Allowed startup without `config.yml`, made the legacy production workflow manual-only, and added
+  Connect Cloud variables, manifest tooling, instructions, and an acceptance checklist.
+
+## Verification record
+
+- Commit `93f902a` passed 102 tests and workflow YAML parsing.
+- Later tests cover age normalization, valid unrestricted recipients, HTML escaping, MIME
+  attachments, header injection, and sanitized failures.
+- Changed R/test files parse, `renv.lock` is valid JSON, dependency declarations agree, and
+  `git diff --check` passes.
+- The full `devtools::test()` suite passes on the working tree (77 tests, 0 failures).
+- The Handsontable 10.0.0 override was subsequently reverted: the app now serves the 6.2.2 build
+  bundled with `rhandsontable`, and the override code (`secureRHandsontable()`,
+  `handsontablePatchedDependency()`), the vendored `inst/www/handsontable-10.0.0/` assets, the
+  `handsontable_license_key` config, and the `test-shiny-utils.R` regression guard were removed.
+  Residual 6.2.2 XSS risk is mitigated by the retained grid hooks and server-side validators.
+- The live Connect Cloud acceptance test remains required before release. Generate and commit
+  `manifest.json` from the exact GitHub revision.
+
+## Residual risks and decisions
+
+- Free-text comments can contain PHI despite the warning.
+- A patient recipient address can link identity to simulation data in the external mail system.
+- Bookmark retention/access depend on Connect Cloud configuration.
+- Per-session rate limiting requires platform-level reinforcement.
+- CSP permits inline script/style execution required by the current Shiny/htmlwidgets stack.
+- Code hardening alone cannot establish HIPAA compliance; contracts, access controls, retention,
+  monitoring, incident response, and institutional policy are also required.


### PR DESCRIPTION
### 🧩 #273 split — 8 stacked PRs (review & merge in order)

- [ ] 1/8 · #274 — Server-side input validation
- [ ] 2/8 · #275 — Age/PHI normalization
- [ ] 3/8 · #276 — Bookmarking privacy
- [ ] 4/8 · #277 — Email/SMTP hardening
- [ ] 5/8 · #278 — Front-end injection hardening
- [ ] 6/8 · #279 — Handsontable cleanup
- [ ] 7/8 · #280 — CI/CD & deployment
- [ ] **8/8 · #281 — Documentation ← this PR**

Related but independent (off `master`): #282 — GitHub Source link.

---

**Part 8 of 8 (final)** splitting #273. **Stacked on #280** (base = `security/07-ci`).

## What this PR does
Documentation for everything in PRs 1–7.

- Security & privacy: `security-deployment.md`, `privacy-and-phi.md`, `security-hardening-changelog.md`, `connect-cloud-deployment.md`.
- Architecture map (`architecture.md` / `.html`) refreshed — including the corrected note that `recalculatePK()`/`processdoseTable()` rebuild the per-drug list each run (the skip-unchanged diff is currently inert).
- `README.md` security/deployment links; `CLAUDE.md` security-audit orientation; `AGENTS.md` / `GEMINI.md` work log.

## Reconstruction check
With all 8 PRs applied, the tree is byte-identical to the original `codex/security-hardening` branch (#273) — verified with `git diff`. Docs-only; no code changes.
