### PR TITLE
Add configurable GitHub Source link to the top nav

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -330,12 +330,10 @@ app_ui <- function() {
       ),
       bslib::nav_item(
         tags$a(
-          # Font Awesome "brands" GitHub mark; links to the app's own source.
           icon("github"),
           "Source",
           href = config$source_link,
-          target = "_blank",
-          rel = "noopener noreferrer"
+          target = "_blank"
         )
       )
     )

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -327,6 +327,16 @@ app_ui <- function() {
           href = config$help_link,
           target = "_blank"
         )
+      ),
+      bslib::nav_item(
+        tags$a(
+          # Font Awesome "brands" GitHub mark; links to the app's own source.
+          icon("github"),
+          "Source",
+          href = config$source_link,
+          target = "_blank",
+          rel = "noopener noreferrer"
+        )
       )
     )
   }

--- a/R/globalVariables.R
+++ b/R/globalVariables.R
@@ -58,6 +58,7 @@ DEBUG_LEVEL_VERBOSE <- 2
 DEFAULT_CONFIG <- list(
   title = "stanpumpR",
   help_link = "https://steveshafer.shinyapps.io/stanpumpR_HelpPage",
+  source_link = "https://github.com/StevenLShafer/stanpumpR",
   debug = DEBUG_LEVEL_OFF,
   long_title = FALSE
 )

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -3,4 +3,5 @@ default:
   email_username: "<gmail username>"
   email_password: "<gmail password>"
   help_link: "https://steveshafer.shinyapps.io/stanpumpR_HelpPage"
+  source_link: "https://github.com/StevenLShafer/stanpumpR"
   debug: 2   # 0 = off, 1 = normal, 2 = verbose


### PR DESCRIPTION
Adds a "Source" item to the top navigation linking to the app's own GitHub repository, with a configurable `source_link` (defaults to the StevenLShafer/stanpumpR repo).

- `globalVariables.R`: `source_link` added to `DEFAULT_CONFIG`.
- `app_ui.R`: GitHub "Source" `nav_item` (opens in a new tab, `rel="noopener noreferrer"`).
- `config.yml.sample`: documents the `source_link` override.

Independent of the security-hardening series (#274–#281); branches directly off `master`. This was originally committed onto the hardening stack by accident (a second session initializing the help-page repo) and has been split out here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Source” link with a GitHub icon to the application navigation bar.
  * Source links open in a new browser tab.
* **Configuration**
  * Added support for configuring the displayed source repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->