### PR TITLE
Test: utils helpers (email validation, %btwn%, dose check)

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,65 @@
+# Tests for the small helpers in R/utils.R: %btwn%, isEmailValid,
+# drugHasNonZeroDoses. These had no dedicated coverage. isEmailValid in
+# particular is a security-relevant guard: it is the server-side check that
+# stops the shared mailer from being pointed at multiple / malformed
+# recipients, so the negative cases below double as security assertions.
+#
+# Provenance: drafted by Claude Code (Opus 4.8), 2026-08-13, for the
+# pre-deployment test plan (input validation + security). Verified against
+# R/utils.R on master with devtools::test().
+
+test_that("%btwn% is inclusive and vectorized", {
+  expect_true(5 %btwn% c(1, 10))
+  expect_true(1 %btwn% c(1, 10))    # lower bound inclusive
+  expect_true(10 %btwn% c(1, 10))   # upper bound inclusive
+  expect_false(0 %btwn% c(1, 10))
+  expect_false(11 %btwn% c(1, 10))
+  expect_equal(c(0, 5, 11) %btwn% c(1, 10), c(FALSE, TRUE, FALSE))
+})
+
+test_that("isEmailValid accepts well-formed single addresses", {
+  expect_true(isEmailValid("a@b.com"))
+  expect_true(isEmailValid("steve.shafer@stanford.edu"))
+  expect_true(isEmailValid("user+tag@example.co.uk"))
+  expect_true(isEmailValid("first.last-name@sub.domain.org"))
+})
+
+test_that("isEmailValid rejects malformed addresses", {
+  expect_false(isEmailValid(""))
+  expect_false(isEmailValid("notanemail"))
+  expect_false(isEmailValid("a@b"))          # no TLD
+  expect_false(isEmailValid("@b.com"))       # no local part
+  expect_false(isEmailValid("a@.com"))       # no domain label
+  expect_false(isEmailValid("a b@c.com"))    # embedded space
+})
+
+test_that("isEmailValid rejects multi-recipient and injection payloads", {
+  # These are the security-relevant cases: the shared account must not be
+  # coerced into sending to extra recipients or into header injection.
+  expect_false(isEmailValid("a@b.com, c@d.com"))          # comma list
+  expect_false(isEmailValid("a@b.com;c@d.com"))           # semicolon list
+  expect_false(isEmailValid("a@b.com victim@evil.com"))   # space-separated
+  expect_false(isEmailValid("a@b.com\r\nBcc: victim@evil.com"))  # CRLF header injection
+  expect_false(isEmailValid("a@b.com\nBcc: victim@evil.com"))
+})
+
+test_that("drugHasNonZeroDoses detects any non-zero dose for a drug", {
+  dt <- data.frame(
+    Drug = c("propofol", "propofol", "fentanyl", "ketamine"),
+    Dose = c("100", "0", "0", ""),
+    stringsAsFactors = FALSE
+  )
+  expect_true(drugHasNonZeroDoses(dt, "propofol"))   # 100 is non-zero
+  expect_false(drugHasNonZeroDoses(dt, "fentanyl"))  # only a zero dose
+  expect_false(drugHasNonZeroDoses(dt, "ketamine"))  # only a blank dose
+  expect_false(drugHasNonZeroDoses(dt, "midazolam")) # drug absent from table
+})
+
+test_that("drugHasNonZeroDoses ignores blanks and non-numeric doses", {
+  dt <- data.frame(
+    Drug = c("propofol", "propofol", "propofol"),
+    Dose = c("", "abc", "0"),
+    stringsAsFactors = FALSE
+  )
+  expect_false(drugHasNonZeroDoses(dt, "propofol"))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,17 +1,7 @@
-# Tests for the small helpers in R/utils.R: %btwn%, isEmailValid,
-# drugHasNonZeroDoses. These had no dedicated coverage. isEmailValid in
-# particular is a security-relevant guard: it is the server-side check that
-# stops the shared mailer from being pointed at multiple / malformed
-# recipients, so the negative cases below double as security assertions.
-#
-# Provenance: drafted by Claude Code (Opus 4.8), 2026-08-13, for the
-# pre-deployment test plan (input validation + security). Verified against
-# R/utils.R on master with devtools::test().
-
 test_that("%btwn% is inclusive and vectorized", {
   expect_true(5 %btwn% c(1, 10))
-  expect_true(1 %btwn% c(1, 10))    # lower bound inclusive
-  expect_true(10 %btwn% c(1, 10))   # upper bound inclusive
+  expect_true(1 %btwn% c(1, 10))
+  expect_true(10 %btwn% c(1, 10))
   expect_false(0 %btwn% c(1, 10))
   expect_false(11 %btwn% c(1, 10))
   expect_equal(c(0, 5, 11) %btwn% c(1, 10), c(FALSE, TRUE, FALSE))
@@ -26,40 +16,30 @@ test_that("isEmailValid accepts well-formed single addresses", {
 
 test_that("isEmailValid rejects malformed addresses", {
   expect_false(isEmailValid(""))
+  expect_false(isEmailValid(" a@b.com"))
   expect_false(isEmailValid("notanemail"))
-  expect_false(isEmailValid("a@b"))          # no TLD
-  expect_false(isEmailValid("@b.com"))       # no local part
-  expect_false(isEmailValid("a@.com"))       # no domain label
-  expect_false(isEmailValid("a b@c.com"))    # embedded space
+  expect_false(isEmailValid("a@b"))
+  expect_false(isEmailValid("@b.com"))
+  expect_false(isEmailValid("a@.com"))
+  expect_false(isEmailValid("a b@c.com"))
 })
 
 test_that("isEmailValid rejects multi-recipient and injection payloads", {
-  # These are the security-relevant cases: the shared account must not be
-  # coerced into sending to extra recipients or into header injection.
-  expect_false(isEmailValid("a@b.com, c@d.com"))          # comma list
-  expect_false(isEmailValid("a@b.com;c@d.com"))           # semicolon list
-  expect_false(isEmailValid("a@b.com victim@evil.com"))   # space-separated
-  expect_false(isEmailValid("a@b.com\r\nBcc: victim@evil.com"))  # CRLF header injection
+  expect_false(isEmailValid("a@b.com, c@d.com"))
+  expect_false(isEmailValid("a@b.com;c@d.com"))
+  expect_false(isEmailValid("a@b.com victim@evil.com"))
+  expect_false(isEmailValid("a@b.com\r\nBcc: victim@evil.com"))
   expect_false(isEmailValid("a@b.com\nBcc: victim@evil.com"))
 })
 
 test_that("drugHasNonZeroDoses detects any non-zero dose for a drug", {
   dt <- data.frame(
-    Drug = c("propofol", "propofol", "fentanyl", "ketamine"),
-    Dose = c("100", "0", "0", ""),
-    stringsAsFactors = FALSE
+    Drug = c("propofol", "propofol", "fentanyl", "fentanyl", "fentanyl", "ketamine"),
+    Dose = c("100", "0", "0", "", "abc", "0")
   )
-  expect_true(drugHasNonZeroDoses(dt, "propofol"))   # 100 is non-zero
-  expect_false(drugHasNonZeroDoses(dt, "fentanyl"))  # only a zero dose
-  expect_false(drugHasNonZeroDoses(dt, "ketamine"))  # only a blank dose
-  expect_false(drugHasNonZeroDoses(dt, "midazolam")) # drug absent from table
+  expect_true(drugHasNonZeroDoses(dt, "propofol"))
+  expect_false(drugHasNonZeroDoses(dt, "fentanyl"))
+  expect_false(drugHasNonZeroDoses(dt, "ketamine"))
+  expect_false(drugHasNonZeroDoses(dt, "midazolam"))
 })
 
-test_that("drugHasNonZeroDoses ignores blanks and non-numeric doses", {
-  dt <- data.frame(
-    Drug = c("propofol", "propofol", "propofol"),
-    Dose = c("", "abc", "0"),
-    stringsAsFactors = FALSE
-  )
-  expect_false(drugHasNonZeroDoses(dt, "propofol"))
-})


### PR DESCRIPTION
Adds `tests/testthat/test-utils.R`, covering the previously-untested helpers in `R/utils.R`.

- **`%btwn%`** — inclusive bounds, vectorized behavior.
- **`isEmailValid`** — accepts well-formed single addresses; rejects malformed ones, **multi-recipient lists** (comma/semicolon/space separated), and **CRLF header-injection** payloads. This is the server-side guard that keeps the shared stanpumpR mailer from being pointed at extra/forged recipients, so the negatives are security assertions.
- **`drugHasNonZeroDoses`** — detects a non-zero dose, ignores blanks / non-numeric doses / absent drugs.

Verified green locally against master's code. Part of the pre-deployment test plan — #285 / #287, tracked in #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for inclusive and vectorized range checks.
  * Added validation tests for valid, malformed, multi-recipient, and header-injection email inputs.
  * Added tests for detecting non-zero drug doses, including missing, blank, and non-numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->