### PR TITLE
Test: add missing oliceridine drug test

### DIFF
--- a/tests/testthat/test-drugs-oliceridine.R
+++ b/tests/testthat/test-drugs-oliceridine.R
@@ -1,0 +1,57 @@
+# Tests for drugs_oliceridine.R. Oliceridine was the only drug (besides
+# remimazolam) without a test file.
+#
+# The model is covariate-independent (fixed volumes/clearances from Dahan
+# 2020), so beyond the usual snapshot the tests assert that covariates do not
+# change the PK and that the structure matches what getDrugPK() consumes.
+#
+# The reference is asserted with expect_match on the author/journal rather
+# than an exact string, so the test survives citation-formatting updates
+# (e.g. the drug-reference-citations work) without churn.
+#
+# Provenance: drafted by Claude Code (Opus 4.8), 2026-08-13, for the
+# pre-deployment test plan (drug library). Expected values verified by
+# running drugs_oliceridine.R directly: cl1 = 31.7/60, cl2 = 37.5/60.
+
+test_that("returns the correct calculations", {
+  actual <- oliceridine(weight = 70, height = 170, age = 50, sex = "male")
+
+  expect_equal_rounded(
+    actual$PK,
+    list(
+      default = list(
+        v1 = 28,
+        v2 = 29.1,
+        v3 = 1,             # placeholder: model is effectively 2-compartment
+        cl1 = 0.5283333,    # 31.7 L/h / 60 = L/min
+        cl2 = 0.625,        # 37.5 L/h / 60
+        cl3 = 0
+      )
+    )
+  )
+  expect_equal(actual$tPeak, 15)   # 0.25 h * 60 = minutes
+  expect_match(actual$reference, "Dahan")
+})
+
+test_that("PK does not vary with covariates (fixed model)", {
+  a <- oliceridine(70, 170, 50, "male")
+  b <- oliceridine(40, 150, 25, "female")
+  c <- oliceridine(120, 190, 80, "male")
+  expect_equal(a$PK, b$PK)
+  expect_equal(a$PK, c$PK)
+})
+
+test_that("return structure has the fields the engine consumes", {
+  actual <- oliceridine(70, 170, 50, "male")
+  expect_named(
+    actual,
+    c("PK", "tPeak", "MEAC", "typical", "upperTypical", "lowerTypical",
+      "reference")
+  )
+  expect_named(actual$PK, "default")
+  expect_named(actual$PK$default, c("v1", "v2", "v3", "cl1", "cl2", "cl3"))
+  # Volumes and clearances the engine divides by must be positive
+  expect_gt(actual$PK$default$v1, 0)
+  expect_gt(actual$PK$default$cl1, 0)
+  expect_gt(actual$tPeak, 0)
+})


### PR DESCRIPTION
Adds `tests/testthat/test-drugs-oliceridine.R` — oliceridine was one of two drugs (with remimazolam) lacking a `test-drugs-*.R` file.

- Standard PK snapshot: fixed Dahan 2020 volumes/clearances (`cl1 = 31.7/60`, `cl2 = 37.5/60` L/min), `tPeak = 15` min.
- Asserts the model is covariate-independent (same PK across three very different patients).
- Return-structure check: the named fields `getDrugPK()` consumes, positive volumes/clearances.
- The `reference` is asserted via author substring (`"Dahan"`) rather than exact string, so this test passes on master today **and** after the `drug-reference-citations` branch merges — the shape-not-exact-match approach recommended in #284.

Verified green locally against master. Part of the pre-deployment test plan — #284, tracked in #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for oliceridine pharmacokinetic calculations.
  * Verified expected pharmacokinetic values, peak timing, reference metadata, and covariate-independent behavior.
  * Confirmed return fields, component names, and required positive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->