### PR TITLE
only increase email send count after an email successfully sends, otherwise failed attempts will count

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -550,7 +550,6 @@ app_server <- function(input, output, session) {
         return()
       }
 
-      # Per-session cap to prevent the shared account being used as a relay.
       if (emailSendCount() >= EMAIL_SESSION_LIMIT) {
         shinyalert::shinyalert(
           "Send limit reached",
@@ -559,7 +558,6 @@ app_server <- function(input, output, session) {
         )
         return()
       }
-      emailSendCount(emailSendCount() + 1)
 
       values <- list(
         comments = input$emailComments,
@@ -593,6 +591,7 @@ app_server <- function(input, output, session) {
       shinycssloaders::hidePageSpinner()
 
       if (isTRUE(emailRetval)) {
+        emailSendCount(emailSendCount() + 1)
         shinyalert::shinyalert("Email sent", type = "success", closeOnClickOutside = TRUE)
       } else {
         shinyalert::shinyalert("Error sending email", emailRetval, type = "error", closeOnClickOutside = TRUE)

--- a/R/globalVariables.R
+++ b/R/globalVariables.R
@@ -24,8 +24,7 @@ defaultSex <- "female"
 # Resolution for linear interpolation
 RESOLUTION <- 100
 
-# Max number of slides a single session may email, to limit abuse of the
-# shared sending account (the app is unauthenticated and public).
+# Max number of emails a single session can send out, to limit abuse
 EMAIL_SESSION_LIMIT <- 25
 
 # Be sure there are more items below then potential facets on the simulation plot


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed email delivery attempts no longer count toward the session’s email limit.
  * Email limits now accurately reflect successfully sent emails.

* **Documentation**
  * Updated the session email limit description for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->