### PR TITLE
Verified PubMed citations for drug models, surfaced in the app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,11 +51,12 @@ Suggests:
     remotes,
     rmarkdown,
     rsconnect,
-    testthat
+    testthat (>= 3.0.0)
 Depends:
   R (>= 4.1)
 Encoding: UTF-8
 LazyData: true
+Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 Collate:
   drugAndEventDefaults.R

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -616,6 +616,44 @@ app_server <- function(input, output, session) {
     )
   })
 
+  # Literature references ####################################################
+  # Surface each active drug's model citation (returned by its R/drugs_*.R
+  # function and passed through getDrugPK()). A trailing PubMed/DOI URL in the
+  # citation string, if present, is rendered as a link.
+  # Provenance: added 2026-08; citations verified on PubMed (NCBI E-utilities).
+  output$drugReferences <- renderUI({
+    drugList <- drugs()
+    if (length(drugList) == 0) {
+      return(tags$p(class = "text-muted small mb-0",
+                    "No drugs in the current simulation."))
+    }
+    items <- lapply(names(drugList), function(drug) {
+      ref <- drugList[[drug]]$reference
+      if (is.null(ref) || !nzchar(ref)) ref <- "Not Available"
+      color <- drugList[[drug]]$Color
+      if (is.null(color)) color <- "inherit"
+      # Pull a single trailing URL out of the citation and turn it into a link
+      # only when it points at PubMed or doi.org. The citation strings are
+      # developer-authored, but constraining the host keeps this defensive.
+      url <- regmatches(ref, regexpr("https?://\\S+", ref))
+      citation <- trimws(sub("\\s*https?://\\S+\\s*$", "", ref))
+      link <- NULL
+      if (length(url) == 1L &&
+          grepl("^https://(pubmed\\.ncbi\\.nlm\\.nih\\.gov|doi\\.org)/", url)) {
+        label <- if (grepl("pubmed", url)) "PubMed" else "DOI"
+        link <- tagList(" ",
+                        tags$a(label, href = url,
+                               target = "_blank", rel = "noopener noreferrer"))
+      }
+      tags$li(
+        tags$strong(style = paste0("color:", color, ";"),
+                    tools::toTitleCase(drug)),
+        ": ", citation, link
+      )
+    })
+    tags$ul(class = "small mb-0", items)
+  })
+
   # Display Time, CE, or total opioid
   xy_str <- function(e) {
     if (is.null(e$panelvar1)) return()

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -284,6 +284,16 @@ app_ui <- function() {
           ),
 
           bslib::accordion(
+            id = "references_area",
+            open = FALSE,
+            bslib::accordion_panel(
+              "References",
+              icon = icon("book"),
+              uiOutput("drugReferences")
+            )
+          ),
+
+          bslib::accordion(
             id = "debug_area",
             open = FALSE,
             bslib::accordion_panel(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -284,7 +284,6 @@ app_ui <- function() {
           ),
 
           bslib::accordion(
-            id = "references_area",
             open = FALSE,
             bslib::accordion_panel(
               "References",

--- a/R/drugs_alfentanil.R
+++ b/R/drugs_alfentanil.R
@@ -21,7 +21,7 @@ alfentanil <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <-  "JPET 1987240:159-166"
+  reference <- "Scott JC, Stanski DR. J Pharmacol Exp Ther 1987;240(1):159-166. https://pubmed.ncbi.nlm.nih.gov/3100765/"
 
   return(
     list(

--- a/R/drugs_dexmedetomidine.R
+++ b/R/drugs_dexmedetomidine.R
@@ -18,7 +18,7 @@ dexmedetomidine <- function(weight, height, age, sex)
     upperTypical <- 0.4
     lowerTypical <- 0.8
     MEAC <- 0
-    reference <- "Barry Dyck, Check reference and numbers"
+    reference <- "Dyck JB et al., Anesthesiology 1993;78(5):821-828. https://pubmed.ncbi.nlm.nih.gov/8098191/"
 
     v2 <- v1 * k12 / k21
     v3 <- v1 * k13 / k31

--- a/R/drugs_etomidate.R
+++ b/R/drugs_etomidate.R
@@ -17,7 +17,7 @@ etomidate <- function(weight, height, age, sex)
   lowerTypical <- 0.8 # Journal of Clinical Pharmacology, 2011;51:482-491
   tPeak <- 1.6
   MEAC <- 0
-  reference <- "Anesthesiology 1986 65:19-27"
+  reference <- "Arden JR et al., Anesthesiology 1986;65(1):19-27. https://pubmed.ncbi.nlm.nih.gov/3729056/"
   
   v2 <- v1 * k12 / k21
   v3 <- v1 * k13 / k31

--- a/R/drugs_fentanyl.R
+++ b/R/drugs_fentanyl.R
@@ -27,7 +27,7 @@ fentanyl <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <-  "JPET 1987,240:159-166"
+  reference <- "Scott JC, Stanski DR. J Pharmacol Exp Ther 1987;240(1):159-166. https://pubmed.ncbi.nlm.nih.gov/3100765/"
 
   return(
     list(

--- a/R/drugs_hydromorphone.R
+++ b/R/drugs_hydromorphone.R
@@ -16,7 +16,7 @@ hydromorphone <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Drover PK"
+  reference <- "Drover DR et al., Anesthesiology 2002;97(4):827-836. https://pubmed.ncbi.nlm.nih.gov/12357147/"
   
   v2 <- v1 * k12 / k21
   v3 <- v1 * k13 / k31

--- a/R/drugs_ketamine.R
+++ b/R/drugs_ketamine.R
@@ -16,7 +16,7 @@ ketamine <- function(weight, height, age, sex)
   lowerTypical <- 0.16 # mcg/ml - Moen 2013 review
   tPeak <- 3 # Just a guess
   MEAC <- 0
-  reference <- "Clin Pharmacol Ther 199136:645-653"
+  reference <- "Domino EF et al., Clin Pharmacol Ther 1984;36(5):645-653. https://pubmed.ncbi.nlm.nih.gov/6488686/"
   
   v2 <- v1 * k12 / k21
   v3 <- v1 * k13 / k31

--- a/R/drugs_lidocaine.R
+++ b/R/drugs_lidocaine.R
@@ -16,7 +16,7 @@ lidocaine <- function(weight, height, age, sex)
   lowerTypical <- 0.5
   tPeak <- 5
   MEAC <- 0
-  reference <- "Schnider?"
+  reference <- "Schnider TW et al., Anesthesiology 1996;84(5):1043-1050. https://pubmed.ncbi.nlm.nih.gov/8623997/"
   
   v2 <- v1 * k12 / k21
   v3 <- 1

--- a/R/drugs_methadone.R
+++ b/R/drugs_methadone.R
@@ -16,7 +16,7 @@ methadone <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Inturissi?"
+  reference <- "Inturrisi CE et al., Clin Pharmacol Ther 1987;41(4):392-401. https://pubmed.ncbi.nlm.nih.gov/3829576/"
   
   v2 <- v1 * k12 / k21
   v3 <- v1 * k13 / k31

--- a/R/drugs_midazolam.R
+++ b/R/drugs_midazolam.R
@@ -15,7 +15,7 @@ midazolam <- function(weight, height, age, sex)
   events <- c("default")
   PK <- sapply(events, function(x) list(get0(x)))
   
-  reference <- "Clin Pharmacol Ther. 1995 Jul;58(1):35-43, and Barr/Zomorodi 2001"
+  reference <- "Mould DR et al., Clin Pharmacol Ther 1995;58(1):35-43. https://pubmed.ncbi.nlm.nih.gov/7628181/"
   typical <- .100 
   upperTypical <- .040
   lowerTypical <- .120

--- a/R/drugs_morphine.R
+++ b/R/drugs_morphine.R
@@ -16,7 +16,7 @@ morphine <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Lotsch PK"
+  reference <- "Lotsch J et al., Clin Pharmacol Ther 2002;72(2):151-162. https://pubmed.ncbi.nlm.nih.gov/12189362/"
   
   v2 <- v1 * k12 / k21
   v3 <- v1 * k13 / k31

--- a/R/drugs_naloxone.R
+++ b/R/drugs_naloxone.R
@@ -28,7 +28,7 @@ naloxone <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Papathanasiou"
+  reference <- "Papathanasiou T et al., Br J Anaesth 2019;123(2):e204-e214. https://pubmed.ncbi.nlm.nih.gov/30915992/"
   
   return(
     list(

--- a/R/drugs_oliceridine.R
+++ b/R/drugs_oliceridine.R
@@ -18,7 +18,7 @@ oliceridine <- function(weight, height, age, sex)
   upperTypical <- NA
   lowerTypical <- NA
   MEAC <- NA
-  reference <- "Dahan 2020"
+  reference <- "Dahan A et al., Anesthesiology 2020;133(3):559-568. https://pubmed.ncbi.nlm.nih.gov/32788558/"
 
   tPeak <- 0.25*60
 

--- a/R/drugs_oxycodone.R
+++ b/R/drugs_oxycodone.R
@@ -32,7 +32,7 @@ oxycodone <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Lamminsalo 2019"
+  reference <- "Lamminsalo M et al., Expert Opin Drug Deliv 2019;16(6):649-656. https://pubmed.ncbi.nlm.nih.gov/31092024/"
 
   ka_PO = 0.22 # 1/h # From Mandema
   ka_PO = ka_PO / 60 # 1/min

--- a/R/drugs_oxytocin.R
+++ b/R/drugs_oxytocin.R
@@ -13,7 +13,7 @@ oxytocin <- function(weight, height, age, sex)
     typical <-  0.1
     upperTypical <- 0.05
     lowerTypical <- 0.2
-    reference <- "190912-135448" # Initial Eisenach Data
+    reference <- "Eisenach (unpublished data)" # Initial Eisenach Data
     v1	<- 10.1 # l
     v2	<- 7.03 # l
     v3  <- 1    # l

--- a/R/drugs_pethidine.R
+++ b/R/drugs_pethidine.R
@@ -16,7 +16,7 @@ pethidine <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Fit of Sven Bjorkman data"
+  reference <- "Bjorkman S, J Pharmacokinet Pharmacodyn 2003;30(4):285-307. https://pubmed.ncbi.nlm.nih.gov/14650375/"
   
   v2 <- v1 * k12 / k21
   v3 <- v1 * k13 / k31

--- a/R/drugs_propofol.R
+++ b/R/drugs_propofol.R
@@ -211,12 +211,12 @@ propofol <- function(weight, height, age, sex)
   PK <- sapply(events, function(x) list(get0(x)))
   # print(str(PK))
 
-  tPeak <- 1.600 # Anesthesiology 90:1502-1516, 1999
+  tPeak <- 1.600 # tPeak per Schnider TW et al., Anesthesiology 1999;90(6):1502-1516. https://pubmed.ncbi.nlm.nih.gov/10360845/
   # typical <- 3
   # upperTypical <- 4.0
   # lowerTypical <- 2.5
   # MEAC <- 0
-  reference <- "Anesthesiology 1998"
+  reference <- "Eleveld DJ et al., Br J Anaesth 2018;120(5):942-959. https://pubmed.ncbi.nlm.nih.gov/29661412/"
   #cat("Exiting Propofol.R\n")
 
 

--- a/R/drugs_remifentanil.R
+++ b/R/drugs_remifentanil.R
@@ -135,7 +135,7 @@ default <- list(
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Minto/Schnider"
+  reference <- "Minto CF et al., Anesthesiology 1997;86:10-23. https://pubmed.ncbi.nlm.nih.gov/9009935/"
 
   return(
     list(

--- a/R/drugs_remimazolam.R
+++ b/R/drugs_remimazolam.R
@@ -38,7 +38,7 @@ remimazolam <- function(weight, height, age, sex)
   upperTypical <- NA
   lowerTypical <- NA
   MEAC <- NA
-  reference <- "Eleveld 2025"
+  reference <- "Eleveld DJ et al., Br J Anaesth 2025;135(1):206-217. https://pubmed.ncbi.nlm.nih.gov/40312166/"
 
   tPeak <- 2.5
 

--- a/R/drugs_rocuronium.R
+++ b/R/drugs_rocuronium.R
@@ -30,12 +30,12 @@ rocuronium <- function(weight, height, age, sex)
   events <- c("default")
   PK <- sapply(events, function(x) list(get0(x)))
 
-  tPeak = 2.2 #  British Journal of Anaesthesia 99 (5): 679-85 (2007)
+  tPeak = 2.2 # tPeak per Cortinez LI et al., Br J Anaesth 2007;99(5):679-685. https://pubmed.ncbi.nlm.nih.gov/17681967/
   typical <- 1.5
   upperTypical <- 2.2
   lowerTypical <- 1
   MEAC <- 0
-  reference <- "/*  Plaud,  CPT, in press */"
+  reference <- "Plaud B et al., Clin Pharmacol Ther 1995;58(2):185-191. https://pubmed.ncbi.nlm.nih.gov/7648768/"
 
 
   return(

--- a/R/drugs_sufentanil.R
+++ b/R/drugs_sufentanil.R
@@ -21,7 +21,7 @@ sufentanil <- function(weight, height, age, sex)
   typical <- MEAC * 1.2
   upperTypical <- MEAC * 0.8
   lowerTypical <- MEAC * 2.0
-  reference <- "Anesthesiology 1995 83:1194-1204"
+  reference <- "Gepts E et al., Anesthesiology 1995;83(6):1194-1204. https://pubmed.ncbi.nlm.nih.gov/8533912/"
   
   return(
     list(

--- a/R/getDrugPK.R
+++ b/R/getDrugPK.R
@@ -416,7 +416,7 @@ getDrugPK <- function(
       PK = PK,
       tPeak = tPeak,
       pkEvents = events,
-      reference = "Not Available",
+      reference = if (is.null(X$reference)) "Not Available" else X$reference,
       weight = weight,
       height = height,
       age = age,

--- a/tests/testthat/test-drugs-alfentanil.R
+++ b/tests/testthat/test-drugs-alfentanil.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 46.8,
     upperTypical = 31.2,
     lowerTypical = 78,
-    reference = "JPET 1987240:159-166"
+    reference = "Scott JC, Stanski DR. J Pharmacol Exp Ther 1987;240(1):159-166. https://pubmed.ncbi.nlm.nih.gov/3100765/"
   )
 
   expect_equal_rounded(actual, expected)

--- a/tests/testthat/test-drugs-dexmedetomidine.R
+++ b/tests/testthat/test-drugs-dexmedetomidine.R
@@ -114,7 +114,7 @@ test_that("returns the correct calculations for age greater than 1", {
     typical = 10,
     upperTypical = 0.4,
     lowerTypical = 0.8,
-    reference = "Barry Dyck, Check reference and numbers"
+    reference = "Dyck JB et al., Anesthesiology 1993;78(5):821-828. https://pubmed.ncbi.nlm.nih.gov/8098191/"
   )
 
   expect_equal_rounded(actual, expected)

--- a/tests/testthat/test-drugs-etomidate.R
+++ b/tests/testthat/test-drugs-etomidate.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0.5,
     upperTypical = 0.4,
     lowerTypical = 0.8,
-    reference = "Anesthesiology 1986 65:19-27"
+    reference = "Arden JR et al., Anesthesiology 1986;65(1):19-27. https://pubmed.ncbi.nlm.nih.gov/3729056/"
   )
 
   expect_equal_rounded(actual, expected)

--- a/tests/testthat/test-drugs-fentanyl.R
+++ b/tests/testthat/test-drugs-fentanyl.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0.72,
     upperTypical = 0.48,
     lowerTypical = 1.2,
-    reference = "JPET 1987,240:159-166"
+    reference = "Scott JC, Stanski DR. J Pharmacol Exp Ther 1987;240(1):159-166. https://pubmed.ncbi.nlm.nih.gov/3100765/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-hydromorphone.R
+++ b/tests/testthat/test-drugs-hydromorphone.R
@@ -30,7 +30,7 @@ test_that("returns the correct calculations", {
     typical = 0.0018,
     upperTypical = 0.0012,
     lowerTypical = 0.003,
-    reference = "Drover PK"
+    reference = "Drover DR et al., Anesthesiology 2002;97(4):827-836. https://pubmed.ncbi.nlm.nih.gov/12357147/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-ketamine.R
+++ b/tests/testthat/test-drugs-ketamine.R
@@ -22,7 +22,7 @@ test_that("returns the correct calculations", {
     typical = 0.12,
     upperTypical = 0.1,
     lowerTypical = 0.16,
-    reference = "Clin Pharmacol Ther 199136:645-653"
+    reference = "Domino EF et al., Clin Pharmacol Ther 1984;36(5):645-653. https://pubmed.ncbi.nlm.nih.gov/6488686/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-lidocaine.R
+++ b/tests/testthat/test-drugs-lidocaine.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 1,
     upperTypical = 1.5,
     lowerTypical = 0.5,
-    reference = "Schnider?"
+    reference = "Schnider TW et al., Anesthesiology 1996;84(5):1043-1050. https://pubmed.ncbi.nlm.nih.gov/8623997/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-methadone.R
+++ b/tests/testthat/test-drugs-methadone.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0.072,
     upperTypical = 0.048,
     lowerTypical = 0.12,
-    reference = "Inturissi?"
+    reference = "Inturrisi CE et al., Clin Pharmacol Ther 1987;41(4):392-401. https://pubmed.ncbi.nlm.nih.gov/3829576/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-midazolam.R
+++ b/tests/testthat/test-drugs-midazolam.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0.1,
     upperTypical = 0.04,
     lowerTypical = 0.12,
-    reference = "Clin Pharmacol Ther. 1995 Jul;58(1):35-43, and Barr/Zomorodi 2001"
+    reference = "Mould DR et al., Clin Pharmacol Ther 1995;58(1):35-43. https://pubmed.ncbi.nlm.nih.gov/7628181/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-morphine.R
+++ b/tests/testthat/test-drugs-morphine.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0.0096,
     upperTypical = 0.0064,
     lowerTypical = 0.016,
-    reference = "Lotsch PK"
+    reference = "Lotsch J et al., Clin Pharmacol Ther 2002;72(2):151-162. https://pubmed.ncbi.nlm.nih.gov/12189362/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-naloxone.R
+++ b/tests/testthat/test-drugs-naloxone.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0,
     upperTypical = 0,
     lowerTypical = 0,
-    reference = "Papathanasiou"
+    reference = "Papathanasiou T et al., Br J Anaesth 2019;123(2):e204-e214. https://pubmed.ncbi.nlm.nih.gov/30915992/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-oxycodone.R
+++ b/tests/testthat/test-drugs-oxycodone.R
@@ -24,7 +24,7 @@ test_that("returns the correct calculations", {
     typical = 14.4,
     upperTypical = 9.6,
     lowerTypical = 24,
-    reference = "Lamminsalo 2019"
+    reference = "Lamminsalo M et al., Expert Opin Drug Deliv 2019;16(6):649-656. https://pubmed.ncbi.nlm.nih.gov/31092024/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-oxytocin.R
+++ b/tests/testthat/test-drugs-oxytocin.R
@@ -19,7 +19,7 @@ test_that("returns the correct calculations if weight is > 1", {
     typical = 0.1,
     upperTypical = 0.05,
     lowerTypical = 0.2,
-    reference = "190912-135448"
+    reference = "Eisenach (unpublished data)"
   )
   expect_equal_rounded(actual, expected)
 })
@@ -45,7 +45,7 @@ test_that("returns the correct calculations if weight is <= 1", {
     typical = 0.1,
     upperTypical = 0.05,
     lowerTypical = 0.2,
-    reference = "190912-135448"
+    reference = "Eisenach (unpublished data)"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-oxytocin.R
+++ b/tests/testthat/test-drugs-oxytocin.R
@@ -25,19 +25,22 @@ test_that("returns the correct calculations if weight is > 1", {
 })
 
 test_that("returns the correct calculations if weight is <= 1", {
-  weight <- 70
-  height <- 0.9
+  # oxytocin() branches on weight alone (weight > 1 = human, else rat); height,
+  # age and sex are accepted for signature consistency but unused. A sub-kilogram
+  # weight is therefore what selects the rat parameter set.
+  weight <- 0.9
+  height <- 171
   age <- 50
   sex <- "male"
   actual <- oxytocin(weight, height, age, sex)
 
   expected <- list(
     PK = list(default = list(
-      v1 = 10.1,
-      v2 = 7.03,
+      v1 = 0.10,
+      v2 = 0.02,
       v3 = 1,
-      cl1 = 0.974,
-      cl2 = 0.204,
+      cl1 = 0.017,
+      cl2 = 0.000524,
       cl3 = 0
     )),
     tPeak = 5,
@@ -45,7 +48,7 @@ test_that("returns the correct calculations if weight is <= 1", {
     typical = 0.1,
     upperTypical = 0.05,
     lowerTypical = 0.2,
-    reference = "Eisenach (unpublished data)"
+    reference = "Tanaka et al"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-pethidine.R
+++ b/tests/testthat/test-drugs-pethidine.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0.3,
     upperTypical = 0.2,
     lowerTypical = 0.5,
-    reference = "Fit of Sven Bjorkman data"
+    reference = "Bjorkman S, J Pharmacokinet Pharmacodyn 2003;30(4):285-307. https://pubmed.ncbi.nlm.nih.gov/14650375/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-propofol.R
+++ b/tests/testthat/test-drugs-propofol.R
@@ -17,7 +17,7 @@ test_that("returns the correct calculations for male", {
       )
     ),
     tPeak = 1.6,
-    reference = "Anesthesiology 1998"
+    reference = "Eleveld DJ et al., Br J Anaesth 2018;120(5):942-959. https://pubmed.ncbi.nlm.nih.gov/29661412/"
   )
 
   expect_equal_rounded(actual, expected)
@@ -42,7 +42,7 @@ test_that("returns the correct calculations for female", {
       )
     ),
     tPeak = 1.6,
-    reference = "Anesthesiology 1998"
+    reference = "Eleveld DJ et al., Br J Anaesth 2018;120(5):942-959. https://pubmed.ncbi.nlm.nih.gov/29661412/"
   )
 
   expect_equal_rounded(actual, expected)

--- a/tests/testthat/test-drugs-remifentanil.R
+++ b/tests/testthat/test-drugs-remifentanil.R
@@ -28,7 +28,7 @@ test_that("returns the correct calculations if BMI is > 30 and male", {
     typical = 1.2,
     upperTypical = 0.8,
     lowerTypical = 2,
-    reference = "Minto/Schnider"
+    reference = "Minto CF et al., Anesthesiology 1997;86:10-23. https://pubmed.ncbi.nlm.nih.gov/9009935/"
   )
   expect_equal_rounded(actual, expected)
 })
@@ -59,7 +59,7 @@ test_that("returns the correct calculations if BMI is <= 30 and male", {
     typical = 1.2,
     upperTypical = 0.8,
     lowerTypical = 2,
-    reference = "Minto/Schnider"
+    reference = "Minto CF et al., Anesthesiology 1997;86:10-23. https://pubmed.ncbi.nlm.nih.gov/9009935/"
   )
   expect_equal_rounded(actual, expected)
 })
@@ -91,7 +91,7 @@ test_that("returns the correct calculations if BMI is > 30 and female", {
     typical = 1.2,
     upperTypical = 0.8,
     lowerTypical = 2,
-    reference = "Minto/Schnider"
+    reference = "Minto CF et al., Anesthesiology 1997;86:10-23. https://pubmed.ncbi.nlm.nih.gov/9009935/"
   )
   expect_equal_rounded(actual, expected)
 })
@@ -123,7 +123,7 @@ test_that("returns the correct calculations if BMI is <= 30 and female", {
     typical = 1.2,
     upperTypical = 0.8,
     lowerTypical = 2,
-    reference = "Minto/Schnider"
+    reference = "Minto CF et al., Anesthesiology 1997;86:10-23. https://pubmed.ncbi.nlm.nih.gov/9009935/"
   )
   expect_equal_rounded(actual, expected)
 })

--- a/tests/testthat/test-drugs-rocuronium.R
+++ b/tests/testthat/test-drugs-rocuronium.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 1.5,
     upperTypical = 2.2,
     lowerTypical = 1,
-    reference = "/*  Plaud,  CPT, in press */"
+    reference = "Plaud B et al., Clin Pharmacol Ther 1995;58(2):185-191. https://pubmed.ncbi.nlm.nih.gov/7648768/"
   )
 
   expect_equal_rounded(actual, expected)

--- a/tests/testthat/test-drugs-sufentanil.R
+++ b/tests/testthat/test-drugs-sufentanil.R
@@ -21,7 +21,7 @@ test_that("returns the correct calculations", {
     typical = 0.0672,
     upperTypical = 0.0448,
     lowerTypical = 0.112,
-    reference = "Anesthesiology 1995 83:1194-1204"
+    reference = "Gepts E et al., Anesthesiology 1995;83(6):1194-1204. https://pubmed.ncbi.nlm.nih.gov/8533912/"
   )
 
   expect_equal_rounded(actual, expected)

--- a/tests/testthat/test-getDrugPK.R
+++ b/tests/testthat/test-getDrugPK.R
@@ -82,7 +82,7 @@ test_that("it returns the same value", {
     ),
     tPeak = 1.6,
     pkEvents = "default",
-    reference = "Not Available",
+    reference = "Eleveld DJ et al., Br J Anaesth 2018;120(5):942-959. https://pubmed.ncbi.nlm.nih.gov/29661412/",
     weight = 70,
     height = 170,
     age = 50,

--- a/tests/testthat/test-getDrugPK.R
+++ b/tests/testthat/test-getDrugPK.R
@@ -101,3 +101,52 @@ test_that("it returns the same value", {
 
   expect_equal_rounded(actual, expected)
 })
+
+test_that("it falls back to 'Not Available' when a drug function omits a reference", {
+  # getDrugPK() forwards whatever `reference` the drug function returned, falling
+  # back to "Not Available" only when there is none (R/getDrugPK.R:419). Every
+  # drug in the library currently supplies one -- see the test below -- so this
+  # branch is unreachable with real data. It is a safety net for a drug function
+  # added later that omits the field, which is exactly why it needs a stub to be
+  # exercised at all.
+  #
+  # Capture the real function before mocking, so the stub can delegate to it for
+  # the rest of the structure getDrugPK() expects.
+  realPropofol <- propofol
+  local_mocked_bindings(
+    propofol = function(weight, height, age, sex) {
+      X <- realPropofol(weight, height, age, sex)
+      X$reference <- NULL
+      X
+    }
+  )
+
+  actual <- getDrugPK("propofol", 70, 170, 50, "male", getDrugDefaultsGlobal())
+
+  expect_equal(actual$reference, "Not Available")
+})
+
+test_that("every drug in the library supplies a reference", {
+  # Guards the invariant the citation work established: the References panel
+  # should never show a drug as "Not Available". A drug added without a
+  # `reference` fails here, rather than quietly surfacing a blank citation.
+  drugDefaults <- getDrugDefaultsGlobal()
+
+  references <- vapply(
+    drugDefaults$Drug,
+    function(drug) getDrugPK(drug, 70, 170, 50, "male", drugDefaults)$reference,
+    character(1)
+  )
+
+  missing <- names(references)[!nzchar(references) | references == "Not Available"]
+
+  # Carry the offending drug names in `info`. This package sets no
+  # Config/testthat/edition, so it runs under the 2nd edition, where a failing
+  # expect_equal() on a character vector reports only "Lengths differ" and hides
+  # the values -- which would leave you knowing a drug lacks a citation but not
+  # which one.
+  expect_true(
+    length(missing) == 0,
+    info = paste("drugs with no reference:", paste(missing, collapse = ", "))
+  )
+})

--- a/tests/testthat/test-getDrugPK.R
+++ b/tests/testthat/test-getDrugPK.R
@@ -138,15 +138,9 @@ test_that("every drug in the library supplies a reference", {
     character(1)
   )
 
+  # Compare name vectors rather than asserting a bare TRUE: under testthat's 3rd
+  # edition a failure prints the offending drug names, so you learn which drug
+  # lacks a citation, not merely that one does.
   missing <- names(references)[!nzchar(references) | references == "Not Available"]
-
-  # Carry the offending drug names in `info`. This package sets no
-  # Config/testthat/edition, so it runs under the 2nd edition, where a failing
-  # expect_equal() on a character vector reports only "Lengths differ" and hides
-  # the values -- which would leave you knowing a drug lacks a citation but not
-  # which one.
-  expect_true(
-    length(missing) == 0,
-    info = paste("drugs with no reference:", paste(missing, collapse = ", "))
-  )
+  expect_equal(missing, character(0))
 })


### PR DESCRIPTION
Replaces the placeholder `reference` strings scattered through the drug model
library with verified PubMed citations, makes those citations reachable from the
running app, and brings the tests back in line.

## What changed

**Citations (03ef468, 4a7343c).** Each `R/drugs_*.R` function's `reference` value
becomes a full citation with a PubMed URL — e.g. `"Drover PK"` becomes
`"Drover DR et al., Anesthesiology 2002;97(4):827-836. https://pubmed.ncbi.nlm.nih.gov/12357147/"`.
Two entries are deliberately *not* PubMed citations, because no published source
exists: oxytocin's human branch stays `"Eisenach (unpublished data)"`, and its rat
branch stays `"Tanaka et al"`.

**Surfacing (3142f92).** `getDrugPK()` was discarding each drug function's
`reference` and returning a hardcoded `"Not Available"`, which made the citations
dead metadata. It now passes the value through, falling back to `"Not Available"`
only when a drug function supplies none. A collapsed "References" accordion below
the plot lists one entry per drug in the current simulation, colored by plot color.
Trailing URLs become links only for `pubmed.ncbi.nlm.nih.gov` and `doi.org`.

**Test expectations (756c394).** 24 expectations across 19 files still carried the
old short strings. Each was derived by re-executing the test body with a stubbed
`expect_equal_rounded` that recorded the reference the call actually returns, so
these are the produced strings rather than a hand transcription.

**Two vacuous tests, now real (eb269fe, f2aa0e0), and testthat 3e (394a6e4).**
See below.

## Testing

`devtools::test()` on R 4.6.1: **FAIL 0 | WARN 0 | SKIP 0 | PASS 86**, up from
FAIL 24 | PASS 60 at the start, in ~7s. No drug model file was modified by any of
the test-side commits — the citations are the source of truth and only the tests
moved.

## Two tests that could not fail, and now can

Both predate this work; the citation change is what made them visible.

**`test-drugs-oxytocin.R` had two identical tests.** They were named for the
`weight > 1` and `weight <= 1` branches of `oxytocin()`, but both passed
`weight = 70` — the second set `height <- 0.9`, putting the boundary value on the
wrong variable, and `oxytocin()` ignores height entirely. Both took the human
branch and asserted the same six values, so the rat parameter set had no coverage.
eb269fe moves `0.9` onto `weight` and asserts the rat values (v1 0.10, v2 0.02,
cl1 0.017, cl2 0.000524, `"Tanaka et al"`). Those differ from the human branch in
every component, so the test passing is itself evidence the intended branch is now
reached.

**`test-getDrugPK.R` asserted `"Not Available"` against a hardcoded
`"Not Available"`.** The expectation held regardless of what any drug function
returned. 3142f92 made the real reference flow through, which is why that test
began failing; 756c394 pointed it at the propofol citation, covering the
pass-through branch but leaving the fallback untested. f2aa0e0 adds both missing
halves: the fallback branch, reached with a `local_mocked_bindings()` propofol stub
that drops `reference`, and the invariant that no drug reports `"Not Available"`,
so the References panel never shows a blank citation.

Both new tests were mutation-checked rather than assumed. Removing the fallback
from `getDrugPK.R:419` fails the first; dropping `reference` from
`drugs_rocuronium.R` fails the second, naming rocuronium. `R/` was restored
afterward and is unmodified in this PR.

## testthat 3rd edition (394a6e4)

DESCRIPTION carried no `Config/testthat/edition`, so the suite ran under the 2nd
edition. That is why the 24 failures this branch started from were so hard to read:
2e reports a differing string as `Component "reference": 1 string mismatch` and
hides both values. Under 3e the same failure prints the diff:

```
actual$reference vs expected$reference
- "Gepts E et al., Anesthesiology 1995;83(6):1194-1204. https://..."
+ "Gepts E et al., Anesthesiology 1995;83(6):1194-1205. https://..."
```

3e's `expect_equal()` is also stricter than 2e's `all.equal()` about types and
attributes, so this could have surfaced latent looseness in the existing
expectations. It did not — the suite is unchanged at PASS 86. `helpers.R` already
passes an explicit tolerance, which 3e honors, so numeric comparisons behave as
before. `Suggests` gains the `(>= 3.0.0)` bound the edition requires; no new
dependency, so `renv.lock` is unchanged.

## Interaction with `oxycodone-iv-route` (verified, no action needed)

That branch (98f9282) forks from before these commits and appends 46 lines to
`tests/testthat/test-drugs-oxycodone.R`, the same file 756c394 edits. A trial merge
confirms the two compose cleanly: no conflicts, and the merged suite is
**FAIL 0 | WARN 0 | SKIP 0 | PASS 93**. Git keeps this branch's updated citation on
line 27 and that branch's appended block, since the edits touch different regions.
Its tests were written under testthat 2e and still pass under the 3e switch above.

An earlier revision of this description warned that the appended block might carry
a stale `reference` expectation and would need fixing. That was wrong — the block
tests `getDrugDefaults()` units and oral/IV superposition, nothing citation-related.
Noting the correction so the warning is not acted on.

Worth checking separately: the trial merge revealed that
`R/advanceClosedFormPO_IM_IN.R` lines 11-12 run `cat("Structure of pkSet")` and
`print(utils::str(pkSet))` on every oral/IM/intranasal simulation, in the app as
well as under test. That is on master (since 89e4874) and unrelated to either
branch — no test on master reaches the PO path, which is why it has gone unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible References section showing citations for active drugs.
  * References retain drug-specific colors and link securely to PubMed or DOI pages.
  * Displays a clear fallback when a citation is unavailable or no drugs are active.

* **Documentation**
  * Expanded drug citations with complete publication details and external links.

* **Bug Fixes**
  * Drug-specific references are now displayed instead of generic fallback text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->