### PR TITLE
debug level was beign set only after the first reactive flush, so it was missing the first batch of logs

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -71,6 +71,8 @@ app_server <- function(input, output, session) {
   #                           Initialization                                  #
   #############################################################################
 
+  outputComments(getInstalledPackagesInfo())
+
   outputComments(
     "**********************************************************************\n",
     "*                       Initializing                                 *\n",

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -12,15 +12,16 @@ app_server <- function(input, output, session) {
     showIntroModal()
   }, once = TRUE)
 
-  session$userData$debug <- reactiveVal(config$debug)
+  session$userData$debug <- reactiveVal({
+    query <- parseQueryString(isolate(session$clientData$url_search))
+    if (!is.null(query[["debug"]])) {
+      as.numeric(query[["debug"]])
+    } else {
+      config$debug
+    }
+  })
   observeEvent(input$debug_level, ignoreInit = TRUE, {
     session$userData$debug(input$debug_level)
-  })
-  observe({
-    query <- parseQueryString(session$clientData$url_search)
-    if (!is.null(query[["debug"]])) {
-      session$userData$debug(as.numeric(query[["debug"]]))
-    }
   })
 
   # Write out logs to the log section

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,6 +25,16 @@ isEmailValid <- function(email) {
   nchar(email) == attr(regexpr(regex_email, email, perl = FALSE), "match.length")
 }
 
+# Get a snapshot of the R version and packages, to help with troubleshooting in production
+getInstalledPackagesInfo <- function() {
+  pkgs <- utils::installed.packages()[, c("Package", "Version"), drop = FALSE]
+  pkgs <- pkgs[order(tolower(pkgs[, "Package"])), , drop = FALSE]
+  paste0(
+    R.version.string, "\n", nrow(pkgs), " packages:\n",
+    paste0("  ", pkgs[, "Package"], " ", pkgs[, "Version"], collapse = "\n")
+  )
+}
+
 drugHasNonZeroDoses <- function(dt, drug) {
   drugDoses <- dt[dt$Drug == drug & dt$Dose != "", ]
   any(suppressWarnings(as.numeric(drugDoses$Dose)) != 0, na.rm = TRUE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Debug mode now initializes reliably from the URL or configured default and continues responding to debug-level input changes.
  - Removed unnecessary ongoing synchronization of URL changes into debug state.

- **Diagnostics**
  - Startup output now includes the R version and an alphabetized list of installed packages with their versions to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->