### PR TITLE
move time inputs into their own accordion; fixes #343

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -146,6 +146,21 @@ app_ui <- function() {
               ),
 
               bslib::accordion_panel(
+                "Time",
+                icon = icon("clock"),
+                selectInput(
+                  "timeMode",
+                  "Time Display",
+                  c("Actual time" = "clock",
+                    "Elapsed minutes" = "relative")
+                ),
+                conditionalPanel(
+                  "input.timeMode == 'clock'",
+                  textInput("referenceTime", "Procedure start", placeholder = "HH:MM")
+                )
+              ),
+
+              bslib::accordion_panel(
                 "Graph Options",
                 icon = icon("sliders"),
                 selectInput("typical", "Show typical", c("<none>" = "none","Mid", "Range"), selected = "Range"),
@@ -242,19 +257,6 @@ app_ui <- function() {
             bslib::card(
               bslib::card_header(icon("syringe"), "Doses"),
 
-              bslib::layout_columns(
-                selectInput(
-                  "timeMode",
-                  "Time Display",
-                  c("Actual time" = "clock",
-                    "Elapsed minutes" = "relative")
-                ),
-                conditionalPanel(
-                  "input.timeMode == 'clock'",
-                  textInput("referenceTime", "Procedure start", placeholder = "HH:MM")
-                )
-              ),
-              br(),
               rhandsontable::rHandsontableOutput("doseTableHTML"),
 
               bslib::card_footer(


### PR DESCRIPTION
Looks like this:

<img width="1902" height="826" alt="Image" src="https://github.com/user-attachments/assets/c7fce6ee-7447-4bba-ae22-b6d50eda03a2" />

The "Max Time" dropdown can also go into this accordion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Added a collapsible **Time** panel in the sidebar for time display settings and procedure start time.
  * Removed these controls from the **Doses** card to simplify its layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->