### PR TITLE
if email is not configured properly, show user a message instead of the email form

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -198,9 +198,19 @@ app_ui <- function() {
               bslib::accordion_panel(
                 "Email Slide",
                 icon = icon("envelope"),
-                textInput("recipient", NULL, "", placeholder = "Enter email address"),
-                textAreaInput("emailComments", NULL, "", placeholder = "Comments (optional)", rows = 3),
-                actionButton("sendSlide", "Send", class = "btn-primary")
+                if (is.null(config$email_username) || is.null(config$email_password)) {
+                  div(
+                    class = "info-note",
+                    icon("circle-info"),
+                    "Email is not configured. Please ask admin to set email username and password in app configuration."
+                  )
+                } else {
+                  tagList(
+                    textInput("recipient", NULL, "", placeholder = "Enter email address"),
+                    textAreaInput("emailComments", NULL, "", placeholder = "Comments (optional)", rows = 3),
+                    actionButton("sendSlide", "Send", class = "btn-primary")
+                  )
+                }
               )
             ),
 

--- a/R/sendSlide.R
+++ b/R/sendSlide.R
@@ -20,11 +20,11 @@ sendSlide <- function(
 
     outputComments("Sending email to", recipient)
 
-    if (missing(email_username) || is.null(email_username)) {
-      stop("email username missing")
+    if (is.null(email_username)) {
+      stop("Email username missing")
     }
-    if (missing(email_password) || is.null(email_password)) {
-      stop("email password missing")
+    if (is.null(email_password)) {
+      stop("Email password missing")
     }
 
     emailData <- generateEmail(values, recipient, plotObject, allResults, plotResults, height, width, slide, drugs, drugDefaults)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Email Slide panel now displays setup guidance when email credentials are missing.
  * The recipient field, comments field, and send button remain available when credentials are configured.

* **Bug Fixes**
  * Improved email credential validation and clarified related error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->