### PR TITLE
use safeError() for error messages that are safe to be user-facing; fixes #341

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -114,6 +114,7 @@ app_server <- function(input, output, session) {
   # Routine to output doseTableHTML from doseTable
   output$doseTableHTML <- renderRHandsontable({
     req(doseTableDraft())
+    req(validateDoseTableInput(doseTableDraft()))
 
     profileCode({
       outputComments("Rendering doseTableHTML")
@@ -321,7 +322,9 @@ app_server <- function(input, output, session) {
   })
   sex <- reactive({
     req(input$sex)
-    if (length(input$sex) != 1L || !input$sex %in% c("male", "female")) stop("Invalid sex value.")
+    if (length(input$sex) != 1L || !input$sex %in% c("male", "female")) {
+      stop(safeError("Invalid sex value."))
+    }
     input$sex
   })
 
@@ -430,7 +433,7 @@ app_server <- function(input, output, session) {
 
       requestedMaximum <- suppressWarnings(as.numeric(input$maximum))
       if (!is_valid_number(requestedMaximum) || !requestedMaximum %in% maxtimes$times) {
-        stop("Invalid maximum simulation time.")
+        stop(safeError("Invalid maximum simulation time."))
       }
       plotMaximum <- requestedMaximum
       steps <- maxtimes$steps[maxtimes$times == plotMaximum]
@@ -462,10 +465,10 @@ app_server <- function(input, output, session) {
   simulationPlotRetval <- reactive({
     req(input$plotWidth)
     if (!is_valid_number(input$plotWidth, MIN_PLOT_WIDTH, MAX_PLOT_WIDTH)) {
-      stop("Invalid plot width.")
+      stop(safeError("Invalid plot width."))
     }
     if (!is_valid_number(input$yaxisHeight, MIN_YAXIS_HEIGHT, MAX_YAXIS_HEIGHT)) {
-      stop("Invalid plot height.")
+      stop(safeError("Invalid plot height."))
     }
     profileCode({
       outputComments("In simulationPlotRetval", level = DEBUG_LEVEL_VERBOSE)

--- a/R/server-helpers.R
+++ b/R/server-helpers.R
@@ -63,9 +63,9 @@ checkNumericCovariates <- function(age, weight, height, errorFx = NULL) {
 
 validateDoseTableInput <- function(DT, drugDefaults = getDrugDefaultsGlobal()) {
   if (!is.data.frame(DT) || !all(c("Drug", "Time", "Dose", "Units") %in% names(DT))) {
-    stop(shiny::safeError(("Invalid dose table structure."))
+    stop(shiny::safeError("Invalid dose table structure."))
   }
-  if (nrow(DT) > MAX_DOSE_ROWS) stop(shiny::safeError(("Dose table exceeds the permitted row limit."))
+  if (nrow(DT) > MAX_DOSE_ROWS) stop(shiny::safeError("Dose table exceeds the permitted row limit."))
 
   DT <- cleanDT(DT)
   if (nrow(DT) == 0L) return(invisible(TRUE))
@@ -76,50 +76,50 @@ validateDoseTableInput <- function(DT, drugDefaults = getDrugDefaultsGlobal()) {
     nchar(DT$Units) > MAX_UNIT_STRING_LENGTH,
     na.rm = TRUE
   )) {
-    stop(shiny::safeError(("Dose table contains a value that's too long."))
+    stop(shiny::safeError("Dose table contains a value that's too long."))
   }
 
-  if (any(!DT$Drug %in% drugDefaults$Drug)) stop(shiny::safeError(("Dose table contains an unknown drug."))
-  if (any(!DT$Units %in% allUnits)) stop(shiny::safeError(("Dose table contains unknown dose units."))
+  if (any(!DT$Drug %in% drugDefaults$Drug)) stop(shiny::safeError("Dose table contains an unknown drug."))
+  if (any(!DT$Units %in% allUnits)) stop(shiny::safeError("Dose table contains unknown dose units."))
   if (any(!is.finite(DT$Dose) | DT$Dose < 0 | DT$Dose > MAX_DOSE_VALUE)) {
-    stop(shiny::safeError(("Dose must be finite, non-negative, and within the permitted limit."))
+    stop(shiny::safeError("Dose must be finite, non-negative, and within the permitted limit."))
   }
   if (any(vapply(DT$Time, function(x) !identical(validateTime(x), x), logical(1)))) {
-    stop(shiny::safeError(("Dose table contains an invalid time."))
+    stop(shiny::safeError("Dose table contains an invalid time."))
   }
   invisible(TRUE)
 }
 
 validateEventTableInput <- function(ET, eventDefaults = getEventDefaults()) {
-  if (!is.data.frame(ET) || !all(c("Time", "Event") %in% names(ET))) stop(shiny::safeError(("Invalid event table structure."))
-  if (nrow(ET) > MAX_EVENT_ROWS) stop(shiny::safeError(("Event table exceeds the permitted row limit."))
+  if (!is.data.frame(ET) || !all(c("Time", "Event") %in% names(ET))) stop(shiny::safeError("Invalid event table structure."))
+  if (nrow(ET) > MAX_EVENT_ROWS) stop(shiny::safeError("Event table exceeds the permitted row limit."))
   time <- as.character(ET$Time)
   event <- as.character(ET$Event)
   if (any(nchar(time) > MAX_TIME_STRING_LENGTH | nchar(event) > MAX_DRUGNAME_LENGTH, na.rm = TRUE)) {
-    stop(shiny::safeError(("Event table contains a value that's too long."))
+    stop(shiny::safeError("Event table contains a value that's too long."))
   }
-  if (any(!event %in% eventDefaults$Event)) stop(shiny::safeError(("Event table contains an unknown event."))
+  if (any(!event %in% eventDefaults$Event)) stop(shiny::safeError("Event table contains an unknown event."))
   if (any(vapply(time, function(x) !identical(validateTime(x), x), logical(1)))) {
-    stop(shiny::safeError(("Event table contains an invalid time."))
+    stop(shiny::safeError("Event table contains an invalid time."))
   }
   invisible(TRUE)
 }
 
 validateTargetTableInput <- function(targetTable) {
   if (!is.data.frame(targetTable) || !all(c("Time", "Target") %in% names(targetTable))) {
-    stop(shiny::safeError(("Invalid target table structure."))
+    stop(shiny::safeError("Invalid target table structure."))
   }
-  if (nrow(targetTable) > MAX_TARGET_ROWS) stop(shiny::safeError(("Target table exceeds the permitted row limit."))
+  if (nrow(targetTable) > MAX_TARGET_ROWS) stop(shiny::safeError("Target table exceeds the permitted row limit."))
   time <- as.character(targetTable$Time)
   targetText <- as.character(targetTable$Target)
   target <- suppressWarnings(as.numeric(targetText))
   present <- nzchar(time) | nzchar(targetText)
-  if (any(nchar(time) > MAX_TIME_STRING_LENGTH, na.rm = TRUE)) stop(shiny::safeError(("Target table contains an overlong time."))
+  if (any(nchar(time) > MAX_TIME_STRING_LENGTH, na.rm = TRUE)) stop(shiny::safeError("Target table contains an overlong time."))
   if (any(nzchar(time) & vapply(time, function(x) !identical(validateTime(x), x), logical(1)), na.rm = TRUE)) {
-    stop(shiny::safeError(("Target table contains an invalid time."))
+    stop(shiny::safeError("Target table contains an invalid time."))
   }
   if (any(present & (!is.finite(target) | target < 0 | target > MAX_DOSE_VALUE), na.rm = TRUE)) {
-    stop(shiny::safeError(("Target concentrations must be finite and within the permitted limit."))
+    stop(shiny::safeError("Target concentrations must be finite and within the permitted limit."))
   }
   invisible(TRUE)
 }

--- a/R/server-helpers.R
+++ b/R/server-helpers.R
@@ -63,9 +63,9 @@ checkNumericCovariates <- function(age, weight, height, errorFx = NULL) {
 
 validateDoseTableInput <- function(DT, drugDefaults = getDrugDefaultsGlobal()) {
   if (!is.data.frame(DT) || !all(c("Drug", "Time", "Dose", "Units") %in% names(DT))) {
-    stop(safeError("Invalid dose table structure."))
+    stop(shiny::safeError(("Invalid dose table structure."))
   }
-  if (nrow(DT) > MAX_DOSE_ROWS) stop(safeError("Dose table exceeds the permitted row limit."))
+  if (nrow(DT) > MAX_DOSE_ROWS) stop(shiny::safeError(("Dose table exceeds the permitted row limit."))
 
   DT <- cleanDT(DT)
   if (nrow(DT) == 0L) return(invisible(TRUE))
@@ -76,50 +76,50 @@ validateDoseTableInput <- function(DT, drugDefaults = getDrugDefaultsGlobal()) {
     nchar(DT$Units) > MAX_UNIT_STRING_LENGTH,
     na.rm = TRUE
   )) {
-    stop(safeError("Dose table contains a value that's too long."))
+    stop(shiny::safeError(("Dose table contains a value that's too long."))
   }
 
-  if (any(!DT$Drug %in% drugDefaults$Drug)) stop(safeError("Dose table contains an unknown drug."))
-  if (any(!DT$Units %in% allUnits)) stop(safeError("Dose table contains unknown dose units."))
+  if (any(!DT$Drug %in% drugDefaults$Drug)) stop(shiny::safeError(("Dose table contains an unknown drug."))
+  if (any(!DT$Units %in% allUnits)) stop(shiny::safeError(("Dose table contains unknown dose units."))
   if (any(!is.finite(DT$Dose) | DT$Dose < 0 | DT$Dose > MAX_DOSE_VALUE)) {
-    stop(safeError("Dose must be finite, non-negative, and within the permitted limit."))
+    stop(shiny::safeError(("Dose must be finite, non-negative, and within the permitted limit."))
   }
   if (any(vapply(DT$Time, function(x) !identical(validateTime(x), x), logical(1)))) {
-    stop(safeError("Dose table contains an invalid time."))
+    stop(shiny::safeError(("Dose table contains an invalid time."))
   }
   invisible(TRUE)
 }
 
 validateEventTableInput <- function(ET, eventDefaults = getEventDefaults()) {
-  if (!is.data.frame(ET) || !all(c("Time", "Event") %in% names(ET))) stop(safeError("Invalid event table structure."))
-  if (nrow(ET) > MAX_EVENT_ROWS) stop(safeError("Event table exceeds the permitted row limit."))
+  if (!is.data.frame(ET) || !all(c("Time", "Event") %in% names(ET))) stop(shiny::safeError(("Invalid event table structure."))
+  if (nrow(ET) > MAX_EVENT_ROWS) stop(shiny::safeError(("Event table exceeds the permitted row limit."))
   time <- as.character(ET$Time)
   event <- as.character(ET$Event)
   if (any(nchar(time) > MAX_TIME_STRING_LENGTH | nchar(event) > MAX_DRUGNAME_LENGTH, na.rm = TRUE)) {
-    stop(safeError("Event table contains a value that's too long."))
+    stop(shiny::safeError(("Event table contains a value that's too long."))
   }
-  if (any(!event %in% eventDefaults$Event)) stop(safeError("Event table contains an unknown event."))
+  if (any(!event %in% eventDefaults$Event)) stop(shiny::safeError(("Event table contains an unknown event."))
   if (any(vapply(time, function(x) !identical(validateTime(x), x), logical(1)))) {
-    stop(safeError("Event table contains an invalid time."))
+    stop(shiny::safeError(("Event table contains an invalid time."))
   }
   invisible(TRUE)
 }
 
 validateTargetTableInput <- function(targetTable) {
   if (!is.data.frame(targetTable) || !all(c("Time", "Target") %in% names(targetTable))) {
-    stop(safeError("Invalid target table structure."))
+    stop(shiny::safeError(("Invalid target table structure."))
   }
-  if (nrow(targetTable) > MAX_TARGET_ROWS) stop(safeError("Target table exceeds the permitted row limit."))
+  if (nrow(targetTable) > MAX_TARGET_ROWS) stop(shiny::safeError(("Target table exceeds the permitted row limit."))
   time <- as.character(targetTable$Time)
   targetText <- as.character(targetTable$Target)
   target <- suppressWarnings(as.numeric(targetText))
   present <- nzchar(time) | nzchar(targetText)
-  if (any(nchar(time) > MAX_TIME_STRING_LENGTH, na.rm = TRUE)) stop(safeError("Target table contains an overlong time."))
+  if (any(nchar(time) > MAX_TIME_STRING_LENGTH, na.rm = TRUE)) stop(shiny::safeError(("Target table contains an overlong time."))
   if (any(nzchar(time) & vapply(time, function(x) !identical(validateTime(x), x), logical(1)), na.rm = TRUE)) {
-    stop(safeError("Target table contains an invalid time."))
+    stop(shiny::safeError(("Target table contains an invalid time."))
   }
   if (any(present & (!is.finite(target) | target < 0 | target > MAX_DOSE_VALUE), na.rm = TRUE)) {
-    stop(safeError("Target concentrations must be finite and within the permitted limit."))
+    stop(shiny::safeError(("Target concentrations must be finite and within the permitted limit."))
   }
   invisible(TRUE)
 }

--- a/R/server-helpers.R
+++ b/R/server-helpers.R
@@ -63,9 +63,9 @@ checkNumericCovariates <- function(age, weight, height, errorFx = NULL) {
 
 validateDoseTableInput <- function(DT, drugDefaults = getDrugDefaultsGlobal()) {
   if (!is.data.frame(DT) || !all(c("Drug", "Time", "Dose", "Units") %in% names(DT))) {
-    stop("Invalid dose table structure.")
+    stop(safeError("Invalid dose table structure."))
   }
-  if (nrow(DT) > MAX_DOSE_ROWS) stop("Dose table exceeds the permitted row limit.")
+  if (nrow(DT) > MAX_DOSE_ROWS) stop(safeError("Dose table exceeds the permitted row limit."))
 
   DT <- cleanDT(DT)
   if (nrow(DT) == 0L) return(invisible(TRUE))
@@ -76,50 +76,50 @@ validateDoseTableInput <- function(DT, drugDefaults = getDrugDefaultsGlobal()) {
     nchar(DT$Units) > MAX_UNIT_STRING_LENGTH,
     na.rm = TRUE
   )) {
-    stop("Dose table contains a value that's too long.")
+    stop(safeError("Dose table contains a value that's too long."))
   }
 
-  if (any(!DT$Drug %in% drugDefaults$Drug)) stop("Dose table contains an unknown drug.")
-  if (any(!DT$Units %in% allUnits)) stop("Dose table contains unknown dose units.")
+  if (any(!DT$Drug %in% drugDefaults$Drug)) stop(safeError("Dose table contains an unknown drug."))
+  if (any(!DT$Units %in% allUnits)) stop(safeError("Dose table contains unknown dose units."))
   if (any(!is.finite(DT$Dose) | DT$Dose < 0 | DT$Dose > MAX_DOSE_VALUE)) {
-    stop("Dose must be finite, non-negative, and within the permitted limit.")
+    stop(safeError("Dose must be finite, non-negative, and within the permitted limit."))
   }
   if (any(vapply(DT$Time, function(x) !identical(validateTime(x), x), logical(1)))) {
-    stop("Dose table contains an invalid time.")
+    stop(safeError("Dose table contains an invalid time."))
   }
   invisible(TRUE)
 }
 
 validateEventTableInput <- function(ET, eventDefaults = getEventDefaults()) {
-  if (!is.data.frame(ET) || !all(c("Time", "Event") %in% names(ET))) stop("Invalid event table structure.")
-  if (nrow(ET) > MAX_EVENT_ROWS) stop("Event table exceeds the permitted row limit.")
+  if (!is.data.frame(ET) || !all(c("Time", "Event") %in% names(ET))) stop(safeError("Invalid event table structure."))
+  if (nrow(ET) > MAX_EVENT_ROWS) stop(safeError("Event table exceeds the permitted row limit."))
   time <- as.character(ET$Time)
   event <- as.character(ET$Event)
   if (any(nchar(time) > MAX_TIME_STRING_LENGTH | nchar(event) > MAX_DRUGNAME_LENGTH, na.rm = TRUE)) {
-    stop("Event table contains a value that's too long.")
+    stop(safeError("Event table contains a value that's too long."))
   }
-  if (any(!event %in% eventDefaults$Event)) stop("Event table contains an unknown event.")
+  if (any(!event %in% eventDefaults$Event)) stop(safeError("Event table contains an unknown event."))
   if (any(vapply(time, function(x) !identical(validateTime(x), x), logical(1)))) {
-    stop("Event table contains an invalid time.")
+    stop(safeError("Event table contains an invalid time."))
   }
   invisible(TRUE)
 }
 
 validateTargetTableInput <- function(targetTable) {
   if (!is.data.frame(targetTable) || !all(c("Time", "Target") %in% names(targetTable))) {
-    stop("Invalid target table structure.")
+    stop(safeError("Invalid target table structure."))
   }
-  if (nrow(targetTable) > MAX_TARGET_ROWS) stop("Target table exceeds the permitted row limit.")
+  if (nrow(targetTable) > MAX_TARGET_ROWS) stop(safeError("Target table exceeds the permitted row limit."))
   time <- as.character(targetTable$Time)
   targetText <- as.character(targetTable$Target)
   target <- suppressWarnings(as.numeric(targetText))
   present <- nzchar(time) | nzchar(targetText)
-  if (any(nchar(time) > MAX_TIME_STRING_LENGTH, na.rm = TRUE)) stop("Target table contains an overlong time.")
+  if (any(nchar(time) > MAX_TIME_STRING_LENGTH, na.rm = TRUE)) stop(safeError("Target table contains an overlong time."))
   if (any(nzchar(time) & vapply(time, function(x) !identical(validateTime(x), x), logical(1)), na.rm = TRUE)) {
-    stop("Target table contains an invalid time.")
+    stop(safeError("Target table contains an invalid time."))
   }
   if (any(present & (!is.finite(target) | target < 0 | target > MAX_DOSE_VALUE), na.rm = TRUE)) {
-    stop("Target concentrations must be finite and within the permitted limit.")
+    stop(safeError("Target concentrations must be finite and within the permitted limit."))
   }
   invisible(TRUE)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation across dose, event, target, and simulation settings.
  * Invalid sex, simulation time, plot dimensions, table structure, sizes, ranges, and timing values now produce clearer, safely handled errors.
  * Prevented invalid draft dose tables from being rendered.
  * Corrected validation error handling to ensure consistent feedback throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->