### PR TITLE
move the time inputs out of the Doses card into their own card; fixes #343

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -239,34 +239,45 @@ app_ui <- function() {
               )
             ),
 
-            bslib::card(
-              bslib::card_header(icon("syringe"), "Doses"),
+            div(
+              bslib::card(
+                fill = FALSE,
+                bslib::card_header(icon("clock"), "Time"),
 
-              bslib::layout_columns(
-                selectInput(
-                  "timeMode",
-                  "Time Display",
-                  c("Actual time" = "clock",
-                    "Elapsed minutes" = "relative")
-                ),
-                conditionalPanel(
-                  "input.timeMode == 'clock'",
-                  textInput("referenceTime", "Procedure start", placeholder = "HH:MM")
+                bslib::layout_columns(
+                  selectizeInput(
+                    "timeMode",
+                    "Time Display",
+                    c("Actual time" = "clock",
+                      "Elapsed minutes" = "relative"),
+                    options = list(dropdownParent = "body")
+                  ) |>
+                    attachClass("mb-0"),
+                  conditionalPanel(
+                    "input.timeMode == 'clock'",
+                    textInput("referenceTime", "Procedure start", placeholder = "HH:MM") |>
+                      attachClass("mb-0")
+                  )
                 )
               ),
-              br(),
-              rhandsontable::rHandsontableOutput("doseTableHTML"),
 
-              bslib::card_footer(
-                div(
-                  class = "d-grid",
-                  style = "grid-template-columns: 1fr auto auto; gap: 0.25rem",
-                  actionButton("dosetable_apply", "Apply Changes", icon = icon("circle-check"), class = "btn-primary my-0 btn-lg"),
-                  actionButton("dosetable_undo", NULL, icon = icon("undo"), title = "Undo", class = "my-0 btn-lg btn-outline-primary"),
-                  actionButton("dosetable_redo", NULL, icon = icon("redo"), title = "Redo", class = "my-0 btn-lg btn-outline-primary")
+              bslib::card(
+                bslib::card_header(icon("syringe"), "Doses"),
+
+                rhandsontable::rHandsontableOutput("doseTableHTML"),
+
+                bslib::card_footer(
+                  div(
+                    class = "d-grid",
+                    style = "grid-template-columns: 1fr auto auto; gap: 0.25rem",
+                    actionButton("dosetable_apply", "Apply Changes", icon = icon("circle-check"), class = "btn-primary my-0 btn-lg"),
+                    actionButton("dosetable_undo", NULL, icon = icon("undo"), title = "Undo", class = "my-0 btn-lg btn-outline-primary"),
+                    actionButton("dosetable_redo", NULL, icon = icon("redo"), title = "Redo", class = "my-0 btn-lg btn-outline-primary")
+                  )
                 )
               )
-            )
+            ) |>
+              bslib::as_fill_carrier()
           ),
 
           bslib::accordion(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -248,15 +248,12 @@ app_ui <- function() {
                   selectizeInput(
                     "timeMode",
                     "Time Display",
-                    c("Actual time" = "clock",
-                      "Elapsed minutes" = "relative"),
+                    c("Actual time" = "clock", "Elapsed minutes" = "relative"),
                     options = list(dropdownParent = "body")
-                  ) |>
-                    attachClass("mb-0"),
+                  ),
                   conditionalPanel(
                     "input.timeMode == 'clock'",
-                    textInput("referenceTime", "Procedure start", placeholder = "HH:MM") |>
-                      attachClass("mb-0")
+                    textInput("referenceTime", "Procedure start", placeholder = "HH:MM")
                   )
                 )
               ),


### PR DESCRIPTION
This is the preferred solution by @StevenLShafer 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing around the Time Display and Procedure Start controls.
  * Reformatted time-mode choices while preserving their existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->