### PR TITLE
if a config file doesn't exist, use defaults instead of error

### DIFF
--- a/R/app_run.R
+++ b/R/app_run.R
@@ -1,15 +1,23 @@
 #' Launch Shiny App
 #'
 #' @param config_file Path to a YAML configuration file, read by
-#'   [config::get()]. Any setting it does not specify falls back to the
-#'   package defaults. The file must exist; copy `config.yml.sample` to
+#'   [config::get()]. Any setting that isn't specified in the config file
+#'   falls back to the package defaults. Copy `config.yml.sample` to
 #'   `config.yml` for local use.
 #' @return A Shiny app object, as returned by [shiny::shinyApp()].
 #' @export
 run_app <- function(config_file = "config.yml") {
   options(warn = 1)
 
-  config <- config::get(file = config_file)
+  config <- tryCatch({
+    config::get(file = config_file)
+  }, error = function(e) {
+    if (!grepl("not found", e$message)) {
+      stop(e)
+    }
+    list()
+  })
+
   config <- c(config, DEFAULT_CONFIG[!names(DEFAULT_CONFIG) %in% names(config)])
   .sprglobals$config <- config
 

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -8,8 +8,8 @@ run_app(config_file = "config.yml")
 }
 \arguments{
 \item{config_file}{Path to a YAML configuration file, read by
-\code{\link[config:get]{config::get()}}. Any setting it does not specify falls back to the
-package defaults. The file must exist; copy \code{config.yml.sample} to
+\code{\link[config:get]{config::get()}}. Any setting that isn't specified in the config file
+falls back to the package defaults. Copy \code{config.yml.sample} to
 \code{config.yml} for local use.}
 }
 \value{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The app now starts successfully when its configuration file is missing.
  * Missing configuration settings automatically use package defaults.
  * Configuration errors other than missing-file errors continue to be reported.

* **Documentation**
  * Updated `run_app` guidance to clarify configuration fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->