### PR TITLE
"fill" in events table is never used, so remove all references of it; fixes #241

### DIFF
--- a/R/app_globals.R
+++ b/R/app_globals.R
@@ -9,8 +9,7 @@ doseTableNewRow <-  doseTableInit[7, ]
 
 eventTableInit <- data.frame(
   Time = numeric(0),
-  Event = character(0),
-  Fill = character(0)
+  Event = character(0)
 )
 
 bookmarksToExclude <- c(

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -195,6 +195,8 @@ app_server <- function(input, output, session) {
       ET <- as.data.frame(state$values$ET)
       if (ncol(ET) == 0) {
         ET <- eventTableInit
+      } else {
+        ET <- ET[, c("Time", "Event")]
       }
       eventTable(ET)
       outputComments("eventTable:")
@@ -1088,8 +1090,7 @@ app_server <- function(input, output, session) {
         ET <- eventTable()
         ET <- data.frame(
           Time  = c(ET$Time, clickTime),
-          Event = c(ET$Event, clickEvent),
-          Fill = c(ET$Fill, eventDefaults()$Color[clickEvent == eventDefaults()$Event])
+          Event = c(ET$Event, clickEvent)
         )
         ET <- ET[order(ET$Time,ET$Event),]
         eventTable(ET)
@@ -1205,8 +1206,6 @@ app_server <- function(input, output, session) {
         removeModal()
         ET <- rhandsontable::hot_to_r(input$editEventsTableHTML)
         ET <- ET[!ET$Delete,c("Time","Event")]
-        CROWS <- match(ET$Event, eventDefaults()$Event)
-        ET$Fill <- eventDefaults()$Color[CROWS]
         ET <- ET[order(ET$Time,ET$Event),]
         eventTable(ET)
       }, name = "input$editEventsOK observer")

--- a/tests/testthat/test-multi-PK.R
+++ b/tests/testthat/test-multi-PK.R
@@ -13,7 +13,7 @@ test_that("simulateDrugsWithCovariates passes smoke tests and can generate a plo
     Units = c("mcg", "mcg/kg/min", "mcg/kg/min", "mg", "mcg/kg/min", "mcg/kg/min")
   )
 
-  eventTable <- data.frame(Time = double(), Event = character(), Fill = character())
+  eventTable <- data.frame(Time = double(), Event = character())
 
   output <- simulateDrugsWithCovariates(doseTable, eventTable, weight, height, age, sex, maximum, plotRecovery)
 

--- a/tests/testthat/test-simCpCe.R
+++ b/tests/testthat/test-simCpCe.R
@@ -6,7 +6,7 @@ test_that("it returns the correct array", {
     Units = "mcg/kg/min"
   )
 
-  events <- data.frame( Time = double(), Event = character(), Fill = character())
+  events <- data.frame( Time = double(), Event = character())
 
   PK <- list(
     Color = "#0000C0",

--- a/tests/testthat/test-simulationPlot.R
+++ b/tests/testthat/test-simulationPlot.R
@@ -11,8 +11,7 @@ test_that("simulationPlot yields desired objects", {
 
   eventTable <- data.frame(
     Time = 0,
-    Event = "Event",
-    Fill = "black"
+    Event = "Event"
   )
 
   ## from server.R

--- a/tests/testthat/test-single-PK.R
+++ b/tests/testthat/test-single-PK.R
@@ -9,7 +9,7 @@ test_that("getDrugPK passes smoke tests and can generate a plot", {
     Units = c("mcg", "mcg/kg/min", "mcg/kg/min")
   )
 
-  eventTable <- data.frame(Time = double(), Event = character(), Fill = character())
+  eventTable <- data.frame(Time = double(), Event = character())
 
   PK <- getDrugPK(
     drug = "remifentanil",

--- a/tests/testthat/test-suggest.R
+++ b/tests/testthat/test-suggest.R
@@ -10,8 +10,7 @@ test_that("suggest yields a table with the appropriate columns", {
 
   eventTable <- data.frame(
     Time = 0,
-    Event = "Event",
-    Fill = "black"
+    Event = "Event"
   )
 
   age <- 50

--- a/vignettes/stanpumpR-multi-PK.Rmd
+++ b/vignettes/stanpumpR-multi-PK.Rmd
@@ -40,7 +40,7 @@ doseTable <- data.frame(
 Initialize an empty events table. The table is used by the Shiny app interface for stanpumpR to display events on the plot.
 
 ```{r}
-eventTable <- data.frame(Time = double(), Event = character(), Fill = character())
+eventTable <- data.frame(Time = double(), Event = character())
 ```
 
 Calculate the predicted drug concentrations using simulateDrugsWithCovariates:

--- a/vignettes/stanpumpR-single-PK.Rmd
+++ b/vignettes/stanpumpR-single-PK.Rmd
@@ -36,7 +36,7 @@ doseTable <- data.frame(
 Initialize an empty events table. The table is used by the Shiny app interface for stanpumpR to display events on the plot.
 
 ```{r}
-eventTable <- data.frame( Time = double(), Event = character(), Fill = character())
+eventTable <- data.frame( Time = double(), Event = character())
 ```
 
 Load the pharmacokinetic model parameters. The drug defaults table is loaded for the the specific drug, with default parameters for typical concentration levels, MEAC and emergence/return of spontaneous ventilation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Event tables now contain only **Time** and **Event** information.
  - Removed support for unused event fill/color data when restoring, adding, or editing events.
  - Updated examples and validation coverage to reflect the streamlined event table format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->