### PR TITLE
getDrugPk: dont use default params for the important values, do use default params for the generic value

### DIFF
--- a/R/getDrugPK.R
+++ b/R/getDrugPK.R
@@ -22,12 +22,12 @@
 #'
 #' @export
 getDrugPK <- function(
-  drug = "propofol",
-  weight = 70,
-  height = 170,
-  age = 50,
-  sex = "male",
-  drugDefaults
+  drug,
+  weight,
+  height,
+  age,
+  sex,
+  drugDefaults = getDrugDefaults(drug)
 )
 {
   drugList <- getDrugDefaultsGlobal()$Drug


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated drug pharmacokinetic calculations to use the selected drug’s defaults automatically.
  - Removed hard-coded patient and drug assumptions, improving results for different patient characteristics and medications.

- **Refactor**
  - Updated the calculation interface to require drug and patient details explicitly, with drug defaults supplied automatically when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->