### PR TITLE
getDrugPK: pass the correct reference if available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,12 +50,13 @@ Suggests:
     remotes,
     rmarkdown,
     rsconnect,
-    testthat,
+    testthat (>= 3.0.0), 
     yaml
 Depends:
     R (>= 4.1)
 Encoding: UTF-8
 LazyData: true
+Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.1.0

--- a/R/getDrugPK.R
+++ b/R/getDrugPK.R
@@ -420,7 +420,7 @@ getDrugPK <- function(
       PK = PK,
       tPeak = tPeak,
       pkEvents = events,
-      reference = "Not Available",
+      reference = if (is.null(X$reference)) "Not Available" else X$reference,
       weight = weight,
       height = height,
       age = age,

--- a/tests/testthat/test-getDrugPK.R
+++ b/tests/testthat/test-getDrugPK.R
@@ -82,7 +82,7 @@ test_that("it returns the same value", {
     ),
     tPeak = 1.6,
     pkEvents = "default",
-    reference = "Not Available",
+    reference = "Eleveld DJ et al., Br J Anaesth 2018;120(5):942-959. https://pubmed.ncbi.nlm.nih.gov/29661412/",
     weight = 70,
     height = 170,
     age = 50,
@@ -100,6 +100,33 @@ test_that("it returns the same value", {
   )
 
   expect_equal_rounded(actual, expected)
+})
+
+test_that("it falls back to 'Not Available' when a drug function omits a reference", {
+  expect_equal(getDrugPK("propofol", 70, 170, 50, "male")$reference, "Eleveld DJ et al., Br J Anaesth 2018;120(5):942-959. https://pubmed.ncbi.nlm.nih.gov/29661412/")
+
+  realPropofol <- propofol
+  local_mocked_bindings(
+    propofol = function(...) {
+      X <- realPropofol(...)
+      X$reference <- NULL
+      X
+    }
+  )
+
+  expect_equal(getDrugPK("propofol", 70, 170, 50, "male")$reference, "Not Available")
+})
+
+test_that("every drug in the library supplies a reference", {
+  references <- vapply(
+    getDrugDefaultsGlobal()$Drug,
+    function(drug) getDrugPK(drug, 70, 170, 50, "male")$reference,
+    character(1)
+  )
+
+  missing <- names(references)[!nzchar(references) | references == "Not Available"]
+
+  expect_equal(missing, character(0))
 })
 
 test_that("getDrugPK accepts both documented sex values", {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Drug pharmacokinetic results now display the reference associated with the selected drug when available.
  - Results without an associated reference continue to show “Not Available.”
  - Updated the propofol reference to cite the Eleveld publication.

- **Quality Improvements**
  - Added validation to ensure drug-library entries provide meaningful references and that missing references are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->