### PR TITLE
rewrite the undo/redo mechanism to use {undomanager}

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ First-time local setup: copy `config.yml.sample` → `config.yml`
 - **Deploy**: GitHub Actions — PRs auto-deploy to a test environment; merges to `master` deploy to production (shinyapps.io).
 - **Adding an R package**: add to `DESCRIPTION` first, then `renv::install("pkg")` + `renv::snapshot()`, commit `DESCRIPTION` + `renv.lock` together. For a package that isn't on CRAN, also add it under `Remotes:` in `DESCRIPTION` (e.g. `daattali/undomanager`) and install with `renv::install("user/repo")`, so the deploy can resolve it.
 
+
 ## Known Issues
 
 **Per-drug simulation cache doesn't persist.** `recalculatePK()` resets `drugs[[drug]]$DT` to `NULL` on every touch, so `processdoseTable()`'s change-detection always compares against `NULL`. Result: every drug re-simulates on every reactive invalidation (any covariate/dose/event edit), not just the one that changed. The skip logic exists but has no state to skip against — treat this as a real bug, not expected behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ First-time local setup: copy `config.yml.sample` → `config.yml`
 
 `recalculatePK()` and `processdoseTable()` are *meant* to diff inputs and only re-simulate drugs that changed — see known issues below.
 
-**Dose table lifecycle**: edits land in a draft (`doseTableDraft()`) with undo/redo; `Apply` commits it to the canonical `doseTable()`; `doseTableClean()` (cleaned via `cleanDoseTable()` in `input-tables.R`) is what the rest of the pipeline actually reads. Clicking the plot to add/edit a dose bypasses the draft and applies immediately.
+**Dose table lifecycle**: edits land in a draft held by an `{undomanager}` (`doseTableHistory()`, with `doseTableDraft()` a thin reactive over its `$value`) that owns the undo/redo history; `Apply` commits it to the canonical `doseTable()`; `doseTableClean()` (cleaned via `cleanDoseTable()` in `input-tables.R`) is what the rest of the pipeline actually reads. Clicking the plot to add/edit a dose bypasses the draft and applies immediately, and any direct write to `doseTable()` resets the draft and clears the history.
 
 **Testing/scripting entry point**: `simulateDrugsWithCovariates()` is the exported, Shiny-free API (loops `getDrugPK()` → `simCpCe()` per drug) — used by tests and vignettes to drive the PK/PD core without the app.
 
@@ -47,7 +47,7 @@ First-time local setup: copy `config.yml.sample` → `config.yml`
   3. `tests/testthat/test-drugs-<name>.R` (unit test — pin values with `expect_equal_rounded()` from `tests/testthat/helpers.R`)
 - **Debug logging**: `outputComments()`, active when `?debug=1` is in the URL.
 - **Deploy**: GitHub Actions — PRs auto-deploy to a test environment; merges to `master` deploy to production (shinyapps.io).
-- **Adding an R package**: add to `DESCRIPTION` first, then `renv::install("pkg")` + `renv::snapshot()`, commit `DESCRIPTION` + `renv.lock` together.
+- **Adding an R package**: add to `DESCRIPTION` first, then `renv::install("pkg")` + `renv::snapshot()`, commit `DESCRIPTION` + `renv.lock` together. For a package that isn't on CRAN, also add it under `Remotes:` in `DESCRIPTION` (e.g. `daattali/undomanager`) and install with `renv::install("user/repo")`, so the deploy can resolve it.
 
 ## Known Issues
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,10 @@ Imports:
     stats,
     tidyr,
     tools,
+    undomanager,
     utils
+Remotes:
+    daattali/undomanager
 Suggests:
     devtools,
     knitr,

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -209,15 +209,16 @@ app_server <- function(input, output, session) {
   ## Dose Table Loop  ##
   ######################
 
-  # This is used to hold the current state of the table as the user edits it
-  # without applying it, to allow the user to make many successive edits quickly
-  doseTableDraft <- reactiveVal()
+  # Holds the current state of the table as the user edits it without applying
+  # it, to allow the user to make many successive edits quickly and undo/redo edits
+  doseTableHistory <- undomanager::undomanager(type = "data.frame")$reactive()
 
-  doseTableUndo <- reactiveVal(list())
-  doseTableRedo <- reactiveVal(list())
+  doseTableDraft <- reactive(doseTableHistory()$value)
 
   observeEvent(doseTable(), {
-    doseTableDraft(doseTable())
+    # A newly applied or restored table becomes the draft and starts a fresh
+    # history: there are no earlier drafts to step back to.
+    doseTableHistory()$do(doseTable())$clear()
   })
 
   observe({
@@ -228,31 +229,21 @@ app_server <- function(input, output, session) {
   })
 
   observe({
-    shinyjs::toggleState("dosetable_undo", condition = length(doseTableUndo()) > 0)
-    shinyjs::toggleState("dosetable_redo", condition = length(doseTableRedo()) > 0)
+    shinyjs::toggleState("dosetable_undo", condition = doseTableHistory()$can_undo)
+    shinyjs::toggleState("dosetable_redo", condition = doseTableHistory()$can_redo)
   })
 
   observeEvent(input$dosetable_apply, {
     shinyjs::disable("dosetable_apply")
     doseTable(doseTableDraft())
-    doseTableUndo(list())
-    doseTableRedo(list())
   })
 
   observeEvent(input$dosetable_undo, {
-    req(length(doseTableUndo()) > 0)
-
-    doseTableRedo( c(doseTableRedo(), list(doseTableDraft())) )
-    doseTableDraft( utils::tail(doseTableUndo(), 1)[[1]] )
-    doseTableUndo( utils::head(doseTableUndo(), -1) )
+    doseTableHistory()$undo()
   })
 
   observeEvent(input$dosetable_redo, {
-    req(length(doseTableRedo()) > 0)
-
-    doseTableUndo( c(doseTableUndo(), list(doseTableDraft())) )
-    doseTableDraft( utils::tail(doseTableRedo(), 1)[[1]] )
-    doseTableRedo( utils::head(doseTableRedo(), -1) )
+    doseTableHistory()$redo()
   })
 
   observeEvent(input$doseTableHTML, {
@@ -284,15 +275,11 @@ app_server <- function(input, output, session) {
 
       # make sure that table has changed before updating doseTable reactive
       if ( !identicalTable(doseTableDraft(), data) ) {
-        doseTableUndo( c(doseTableUndo(), list(doseTableDraft())) )
-        doseTableRedo(list())
-
         # add empty row at the bottom if needed
         if (nzchar(utils::tail(data, 1)$Drug)) {
           data[nrow(data) + 1, ] <- ""
         }
-
-        doseTableDraft(data)
+        doseTableHistory()$do(data)
       }
     }, name = "input$doseTableHTML observer")
   })
@@ -413,8 +400,10 @@ app_server <- function(input, output, session) {
 
   observeEvent(input$timeMode, {
     doseTable(doseTableDraft())
-    doseTableUndo(list())
-    doseTableRedo(list())
+    # Clear explicitly rather than relying on the doseTable() observer: if the
+    # draft already matched, that reactiveVal never invalidates and the history
+    # would survive a time-mode switch.
+    doseTableHistory()$clear()
 
     # When switching to relative time, convert any clock times (HH:MM) to minutes
     if (input$timeMode == "relative") {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,15 +78,25 @@ double-click edits a drug.
 1. As a user types into the dose table, JavaScript hooks on the grid do real-time cleanup —
    fixing/converting times, dropping a row if its drug is removed, etc.
 2. **`input$doseTableHTML`** fires after that JS-side cleanup completes, on every edit. The
-   observer converts it to an R data frame with `hot_to_r()` and saves it as `doseTableDraft()`.
-3. **Undo / redo** — pop/push `doseTableDraft()` against the undo/redo stacks. This only ever
-   touches the draft; nothing downstream re-simulates yet.
+   observer converts it to an R data frame with `hot_to_r()` and records it via
+   `doseTableHistory()$do()`.
+3. **Undo / redo** — the draft and its history live in one `{undomanager}`,
+   `doseTableHistory()`. `doseTableDraft()` is a thin reactive over its `$value`.
+   `$do()` records an edit (pushing the previous draft onto the undo stack and discarding 
+   any redo history), and `$undo()` / `$redo()` step through it. This only ever touches
+   the draft; nothing downstream re-simulates yet.
 4. **`input$dosetable_apply`** commits the pending edit: it copies `doseTableDraft()`'s value
    into `doseTable()`, the canonical reactive everything downstream reads from.
 5. `doseTable()` can also be updated directly — by clicking on the plot and adding/editing/
-   deleting a dose from the resulting modal — which bypasses the draft entirely and applies
-   immediately, with no separate confirm step.
-6. **`doseTableClean()`** is what the rest of the pipeline actually depends on. Whenever
+   deleting a dose from the resulting modal, by the edit-doses and suggest-dosing dialogs, or by
+   a URL restore — which bypasses the draft entirely and applies immediately, with no separate
+   confirm step.
+6. Whenever `doseTable()` changes by any route, the observer on it resets the draft to the newly
+   committed table and **clears the undo/redo history**: once the canonical table has moved there
+   is no earlier draft worth stepping back to. The time-mode switch clears the history explicitly
+   instead of relying on that observer, because it assigns `doseTable()` a value that may equal
+   what it already holds, and `reactiveVal` does not notify observers on a no-op assignment.
+7. **`doseTableClean()`** is what the rest of the pipeline actually depends on. Whenever
    `doseTable()` changes, this reactive re-derives a cleaned copy via `cleanDoseTable()` (coerce column
    types, drop incomplete rows, convert clock times to elapsed minutes).
 

--- a/renv.lock
+++ b/renv.lock
@@ -180,6 +180,28 @@
       "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
       "Repository": "CRAN"
     },
+    "backports": {
+      "Package": "backports",
+      "Version": "1.5.1",
+      "Source": "Repository",
+      "Type": "Package",
+      "Title": "Reimplementations of Functions Introduced Since R-3.0.0",
+      "Authors@R": "c( person(\"Michel\", \"Lang\", NULL, \"michellang@gmail.com\", role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0001-9754-0393\")), person(\"Duncan\", \"Murdoch\", NULL, \"murdoch.duncan@gmail.com\", role = c(\"aut\")), person(\"R Core Team\", role = \"aut\"))",
+      "Maintainer": "Michel Lang <michellang@gmail.com>",
+      "Description": "Functions introduced or changed since R v3.0.0 are re-implemented in this package. The backports are conditionally exported in order to let R resolve the function name to either the implemented backport, or the respective base version, if available. Package developers can make use of new functions or arguments by selectively importing specific backports to support older installations.",
+      "URL": "https://github.com/r-lib/backports",
+      "BugReports": "https://github.com/r-lib/backports/issues",
+      "License": "GPL-2 | GPL-3",
+      "NeedsCompilation": "yes",
+      "ByteCompile": "yes",
+      "Depends": [
+        "R (>= 3.0.0)"
+      ],
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.3",
+      "Author": "Michel Lang [cre, aut] (ORCID: <https://orcid.org/0000-0001-9754-0393>), Duncan Murdoch [aut], R Core Team [aut]",
+      "Repository": "CRAN"
+    },
     "base64enc": {
       "Package": "base64enc",
       "Version": "0.1-6",
@@ -375,6 +397,49 @@
       "NeedsCompilation": "no",
       "Author": "Gábor Csárdi [aut, cre, cph] (ORCID: <https://orcid.org/0000-0001-7098-9676>), Winston Chang [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>), Ascent Digital Services [cph, fnd]",
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
+      "Repository": "CRAN"
+    },
+    "checkmate": {
+      "Package": "checkmate",
+      "Version": "2.3.4",
+      "Source": "Repository",
+      "Type": "Package",
+      "Title": "Fast and Versatile Argument Checks",
+      "Description": "Tests and assertions to perform frequent argument checks. A substantial part of the package was written in C to minimize any worries about execution time overhead.",
+      "Authors@R": "c( person(\"Michel\", \"Lang\", NULL, \"michellang@gmail.com\", role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0001-9754-0393\")), person(\"Bernd\", \"Bischl\", NULL, \"bernd_bischl@gmx.net\", role = \"ctb\"), person(\"Dénes\", \"Tóth\", NULL, \"toth.denes@kogentum.hu\", role = \"ctb\", comment = c(ORCID = \"0000-0003-4262-3217\")) )",
+      "URL": "https://mllg.github.io/checkmate/, https://github.com/mllg/checkmate",
+      "URLNote": "https://github.com/mllg/checkmate",
+      "BugReports": "https://github.com/mllg/checkmate/issues",
+      "NeedsCompilation": "yes",
+      "ByteCompile": "yes",
+      "Encoding": "UTF-8",
+      "Depends": [
+        "R (>= 3.0.0)"
+      ],
+      "Imports": [
+        "backports (>= 1.1.0)",
+        "utils"
+      ],
+      "Suggests": [
+        "R6",
+        "fastmatch",
+        "data.table (>= 1.9.8)",
+        "devtools",
+        "ggplot2",
+        "knitr",
+        "magrittr",
+        "microbenchmark",
+        "rmarkdown",
+        "testthat (>= 3.0.4)",
+        "tinytest (>= 1.1.0)",
+        "tibble"
+      ],
+      "License": "BSD_3_clause + file LICENSE",
+      "VignetteBuilder": "knitr",
+      "RoxygenNote": "7.3.3",
+      "Collate": "'AssertCollection.R' 'allMissing.R' 'anyInfinite.R' 'anyMissing.R' 'anyNaN.R' 'asInteger.R' 'assert.R' 'helper.R' 'makeExpectation.R' 'makeTest.R' 'makeAssertion.R' 'checkAccess.R' 'checkArray.R' 'checkAtomic.R' 'checkAtomicVector.R' 'checkCharacter.R' 'checkChoice.R' 'checkClass.R' 'checkComplex.R' 'checkCount.R' 'checkDataFrame.R' 'checkDataTable.R' 'checkDate.R' 'checkDirectoryExists.R' 'checkDisjunct.R' 'checkDouble.R' 'checkEnvironment.R' 'checkFALSE.R' 'checkFactor.R' 'checkFileExists.R' 'checkFlag.R' 'checkFormula.R' 'checkFunction.R' 'checkInt.R' 'checkInteger.R' 'checkIntegerish.R' 'checkList.R' 'checkLogical.R' 'checkMatrix.R' 'checkMultiClass.R' 'checkNamed.R' 'checkNames.R' 'checkNull.R' 'checkNumber.R' 'checkNumeric.R' 'checkOS.R' 'checkPOSIXct.R' 'checkPathForOutput.R' 'checkPermutation.R' 'checkR6.R' 'checkRaw.R' 'checkScalar.R' 'checkScalarNA.R' 'checkSetEqual.R' 'checkString.R' 'checkSubset.R' 'checkTRUE.R' 'checkTibble.R' 'checkVector.R' 'coalesce.R' 'isIntegerish.R' 'matchArg.R' 'qassert.R' 'qassertr.R' 'vname.R' 'wfwl.R' 'zzz.R'",
+      "Author": "Michel Lang [cre, aut] (ORCID: <https://orcid.org/0000-0001-9754-0393>), Bernd Bischl [ctb], Dénes Tóth [ctb] (ORCID: <https://orcid.org/0000-0003-4262-3217>)",
+      "Maintainer": "Michel Lang <michellang@gmail.com>",
       "Repository": "CRAN"
     },
     "cli": {
@@ -4715,6 +4780,40 @@
       "Date": "2023-03-04",
       "NeedsCompilation": "yes",
       "Repository": "CRAN"
+    },
+    "undomanager": {
+      "Package": "undomanager",
+      "Version": "0.1.0",
+      "Source": "GitHub",
+      "Title": "Manage the History of Any Object with Undo/Redo Operations",
+      "Authors@R": "c( person(\"Dean\", \"Attali\", email = \"daattali@gmail.com\", role = c(\"aut\", \"cre\"), comment = c(ORCID=\"0000-0002-5645-3493\") ))",
+      "Description": "Track the history of any R object and move through it with undo and redo operations. Anything can be stored, from a single number to a data frame or an entire application state. A manager can restrict its history to specific classes and cap how many items it keeps, and it can be reactive to integrate with 'Shiny'.",
+      "URL": "https://github.com/daattali/undomanager",
+      "BugReports": "https://github.com/daattali/undomanager/issues",
+      "Depends": [
+        "R (>= 4.0.0)"
+      ],
+      "Imports": [
+        "checkmate",
+        "R6"
+      ],
+      "License": "MIT + file LICENSE",
+      "Encoding": "UTF-8",
+      "Roxygen": "list(markdown = TRUE)",
+      "Suggests": [
+        "testthat (>= 3.0.0)",
+        "shiny"
+      ],
+      "Config/testthat/edition": "3",
+      "Config/roxygen2/version": "8.1.0",
+      "Author": "Dean Attali [aut, cre] (ORCID: <https://orcid.org/0000-0002-5645-3493>)",
+      "Maintainer": "Dean Attali <daattali@gmail.com>",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "daattali",
+      "RemoteRepo": "undomanager",
+      "RemoteRef": "master",
+      "RemoteSha": "6ed4a0990b064f07c1fcbf5bfdbc5ea460622e2f"
     },
     "urlchecker": {
       "Package": "urlchecker",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved draft editing with more reliable undo and redo history for dose-table changes.
  * Undo and redo now apply only to the current draft until changes are applied.

* **Bug Fixes**
  * Applying or restoring a dose table now consistently clears its edit history.
  * Switching time modes clears stale undo/redo history, including when table content is unchanged.

* **Documentation**
  * Clarified dose-table editing, history, and restore behavior, including how direct updates affect drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->